### PR TITLE
Use response object to write data to stream instead stream copy

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
  <PropertyGroup>
-   <Version>4.0.0</Version>
+   <Version>4.0.1</Version>
    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Company>AgentFramework</Company>
     <Authors>Tomislav Markovski, Tobias Looker</Authors>

--- a/src/AgentFramework.AspNetCore/Middleware/AgentMiddleware.cs
+++ b/src/AgentFramework.AspNetCore/Middleware/AgentMiddleware.cs
@@ -57,8 +57,8 @@ namespace AgentFramework.AspNetCore.Middleware
                 if (response != null)
                 {
                     context.Response.ContentType = DefaultMessageService.AgentWireMessageMimeType;
-                    await response.Stream.CopyToAsync(context.Response.Body);
-                }
+					await context.Response.WriteAsync(response.GetData().GetUTF8String());
+				}
                 else
                     await context.Response.WriteAsync(string.Empty);
             }


### PR DESCRIPTION
Fixes an issue that occurs when working with non-web agents where response isn't fully sent back to the client. Affects users of return routing.