### PR TITLE
Proof Protocol added. Issue Protocol fixes. Pool and Ledger service refactor.

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <packageSources>
-        <add key="myget.org" value="https://www.myget.org/F/agent-framework/api/v3/index.json" />
         <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     </packageSources>
 </configuration>

--- a/src/AgentFramework.Core.Handlers/Internal/DefaultProofHandler.cs
+++ b/src/AgentFramework.Core.Handlers/Internal/DefaultProofHandler.cs
@@ -22,10 +22,12 @@ namespace AgentFramework.Core.Handlers.Internal
         /// <value>
         /// The supported message types.
         /// </value>
-        public IEnumerable<MessageType> SupportedMessageTypes => new[]
+        public IEnumerable<MessageType> SupportedMessageTypes => new MessageType[]
         {
-            new MessageType(MessageTypes.ProofRequest),
-            new MessageType(MessageTypes.DisclosedProof)
+            MessageTypes.ProofRequest,
+            MessageTypes.DisclosedProof,
+            MessageTypes.PresentProofNames.Presentation,
+            MessageTypes.PresentProofNames.RequestPresentation
         };
 
         /// <summary>
@@ -39,6 +41,7 @@ namespace AgentFramework.Core.Handlers.Internal
         {
             switch (messageContext.GetMessageType())
             {
+                // v0.1
                 case MessageTypes.ProofRequest:
                 {
                     var request = messageContext.GetMessage<ProofRequestMessage>();
@@ -47,13 +50,30 @@ namespace AgentFramework.Core.Handlers.Internal
                     messageContext.ContextRecord = await _proofService.GetAsync(agentContext, proofId);
                     break;
                 }
-
                 case MessageTypes.DisclosedProof:
                 {
                     var proof = messageContext.GetMessage<ProofMessage>();
                     var proofId = await _proofService.ProcessProofAsync(agentContext, proof);
 
                     messageContext.ContextRecord = await _proofService.GetAsync(agentContext, proofId);
+                    break;
+                }
+
+                // v1.0
+                case MessageTypes.PresentProofNames.RequestPresentation:
+                {
+                    var message = messageContext.GetMessage<RequestPresentationMessage>();
+                    var record = await _proofService.ProcessRequestAsync(agentContext, message, messageContext.Connection);
+
+                    messageContext.ContextRecord = record;
+                    break;
+                }
+                case MessageTypes.PresentProofNames.Presentation:
+                {
+                    var message = messageContext.GetMessage<PresentationMessage>();
+                    var record = await _proofService.ProcessPresentationAsync(agentContext, message);
+
+                    messageContext.ContextRecord = record;
                     break;
                 }
                 default:

--- a/src/AgentFramework.Core/Configuration/TxnAuthorAcceptanceHostedService.cs
+++ b/src/AgentFramework.Core/Configuration/TxnAuthorAcceptanceHostedService.cs
@@ -17,7 +17,7 @@ namespace AgentFramework.Core.Configuration
     {
         private readonly IProvisioningService provisioningService;
         private readonly IWalletRecordService recordService;
-        private readonly ILedgerService _ledgerService;
+        private readonly IPoolService _poolService;
         private readonly IAgentProvider _agentProvider;
         private readonly PoolOptions poolOptions;
 
@@ -25,14 +25,14 @@ namespace AgentFramework.Core.Configuration
             IApplicationLifetime applicationLifetime,
             IProvisioningService provisioningService,
             IWalletRecordService recordService,
-            ILedgerService ledgerService,
+            IPoolService poolService,
             IAgentProvider agentProvider,
             IOptions<PoolOptions> poolOptions)
         {
             applicationLifetime.ApplicationStarted.Register(AcceptTxnAuthorAgreement);
             this.provisioningService = provisioningService;
             this.recordService = recordService;
-            _ledgerService = ledgerService;
+            _poolService = poolService;
             _agentProvider = agentProvider;
             this.poolOptions = poolOptions.Value;
         }
@@ -42,7 +42,7 @@ namespace AgentFramework.Core.Configuration
             if (!poolOptions.AcceptTxnAuthorAgreement) return;
 
             var context = await _agentProvider.GetContextAsync(nameof(TxnAuthorAcceptanceHostedService));
-            var taa = await _ledgerService.LookupTaaAsync(context);
+            var taa = await _poolService.GetTaaAsync(poolOptions.PoolName);
             if (taa != null)
             {
                 var digest = GetDigest(taa);

--- a/src/AgentFramework.Core/Contracts/ICredentialService.cs
+++ b/src/AgentFramework.Core/Contracts/ICredentialService.cs
@@ -227,5 +227,13 @@ namespace AgentFramework.Core.Contracts
         /// <param name="issuerDid">The DID of the issuer who issued the credential and owns the definitions</param>
         /// <returns>The response async.</returns>
         Task RevokeCredentialAsync(IAgentContext agentContext, string credentialId, string issuerDid);
+
+        /// <summary>
+        /// Deletes the credential and it's associated record
+        /// </summary>
+        /// <param name="agentContext"></param>
+        /// <param name="credentialId"></param>
+        /// <returns></returns>
+        Task DeleteCredentialAsync(IAgentContext agentContext, string credentialId);
     }
 }

--- a/src/AgentFramework.Core/Contracts/ILedgerService.cs
+++ b/src/AgentFramework.Core/Contracts/ILedgerService.cs
@@ -62,23 +62,6 @@ namespace AgentFramework.Core.Contracts
         Task<string> LookupNymAsync(Pool pool, string did);
 
         /// <summary>
-        /// Lookup Transaction Author Agreement on the ledger
-        /// </summary>
-        /// <param name="context">The agent context</param>
-        /// <param name="version">Taa version. Pass null to get latest.</param>
-        /// <returns></returns>
-        Task<IndyTaa> LookupTaaAsync(IAgentContext context, string version = null);
-
-        /// <summary>
-        /// Lookup acceptance mechanisms list
-        /// </summary>
-        /// <param name="context">The agent context</param>
-        /// <param name="timestamp"></param>
-        /// <param name="version"></param>
-        /// <returns>The acceptance mechanisms list</returns>
-        Task<IndyAml> LookupAmlAsync(IAgentContext context, DateTimeOffset timestamp = default(DateTimeOffset), string version = null);
-
-        /// <summary>
         /// Lookup the ledger transaction async.
         /// </summary>
         /// <param name="pool">The pool.</param>

--- a/src/AgentFramework.Core/Contracts/IPoolService.cs
+++ b/src/AgentFramework.Core/Contracts/IPoolService.cs
@@ -1,4 +1,6 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
+using AgentFramework.Core.Models.Ledger;
 using Hyperledger.Indy.PoolApi;
 
 namespace AgentFramework.Core.Contracts
@@ -25,6 +27,24 @@ namespace AgentFramework.Core.Contracts
         /// <returns>The pool async.</returns>
         /// <param name="poolName">Pool name.</param>
         Task<Pool> GetPoolAsync(string poolName);
+
+        /// <summary>
+        /// Gets the transaction author agreement if one is set on
+        /// the ledger. Otherwise, returns null.
+        /// </summary>
+        /// <param name="poolName"></param>
+        /// <returns></returns>
+        Task<IndyTaa> GetTaaAsync(string poolName);
+
+        /// <summary>
+        /// Gets the acceptance mechanisms list from the ledger
+        /// if one is set.await Otherwise, returns null.
+        /// </summary>
+        /// <param name="poolName"></param>
+        /// <param name="timestamp"></param>
+        /// <param name="version"></param>
+        /// <returns></returns>
+        Task<IndyAml> GetAmlAsync(string poolName, DateTimeOffset timestamp = default(DateTimeOffset), string version = null);
 
         /// <summary>
         /// Creates a pool configuration.

--- a/src/AgentFramework.Core/Contracts/IProofService.cs
+++ b/src/AgentFramework.Core/Contracts/IProofService.cs
@@ -1,5 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
+using AgentFramework.Core.Messages;
 using AgentFramework.Core.Messages.Proofs;
 using AgentFramework.Core.Models.Credentials;
 using AgentFramework.Core.Models.Proofs;
@@ -21,7 +23,11 @@ namespace AgentFramework.Core.Contracts
         /// <param name="proofRequest">An enumeration of attribute we wish the prover to disclose.</param>
         /// <param name="connectionId">Connection identifier of who the proof request will be sent to.</param>
         /// <returns>Proof Request message and identifier.</returns>
+        [Obsolete]
         Task<(ProofRequestMessage, ProofRecord)> CreateProofRequestAsync(IAgentContext agentContext,
+            ProofRequest proofRequest, string connectionId = null);
+
+        Task<(RequestPresentationMessage, ProofRecord)> CreateRequestAsync(IAgentContext agentContext,
             ProofRequest proofRequest, string connectionId = null);
 
         /// <summary>
@@ -32,7 +38,11 @@ namespace AgentFramework.Core.Contracts
         /// <param name="proofRequestJson">A string representation of proof request json object</param>
         /// <param name="connectionId">Connection identifier of who the proof request will be sent to.</param>
         /// <returns>Proof Request message and identifier.</returns>
+        [Obsolete]
         Task<(ProofRequestMessage, ProofRecord)> CreateProofRequestAsync(IAgentContext agentContext,
+            string proofRequestJson, string connectionId);
+
+        Task<(RequestPresentationMessage, ProofRecord)> CreateRequestAsync(IAgentContext agentContext,
             string proofRequestJson, string connectionId);
 
         /// <summary>
@@ -43,7 +53,10 @@ namespace AgentFramework.Core.Contracts
         /// <param name="proofRequest">A proof request.</param>
         /// <param name="connection">Connection.</param>
         /// <returns>Proof identifier.</returns>
+        [Obsolete]
         Task<string> ProcessProofRequestAsync(IAgentContext agentContext, ProofRequestMessage proofRequest, ConnectionRecord connection);
+
+        Task<ProofRecord> ProcessRequestAsync(IAgentContext agentContext, RequestPresentationMessage proofRequest, ConnectionRecord connection);
 
         /// <summary>
         /// Processes a proof and stores it for a given connection.
@@ -52,7 +65,10 @@ namespace AgentFramework.Core.Contracts
         /// <param name="agentContext">Agent Context.</param>
         /// <param name="proof">A proof.</param>
         /// <returns>Proof identifier.</returns>
+        [Obsolete]
         Task<string> ProcessProofAsync(IAgentContext agentContext, ProofMessage proof);
+
+        Task<ProofRecord> ProcessPresentationAsync(IAgentContext agentContext, PresentationMessage proof);
 
         /// <summary>
         /// Processes a proof request and generates an accompanying proof.
@@ -63,7 +79,11 @@ namespace AgentFramework.Core.Contracts
         /// <returns>
         /// The proof.
         /// </returns>
+        [Obsolete]
         Task<string> CreateProofAsync(IAgentContext agentContext,
+            ProofRequest proofRequest, RequestedCredentials requestedCredentials);
+
+        Task<string> CreatePresentationAsync(IAgentContext agentContext,
             ProofRequest proofRequest, RequestedCredentials requestedCredentials);
 
         /// <summary>
@@ -75,7 +95,13 @@ namespace AgentFramework.Core.Contracts
         /// <returns>
         /// The proof.
         /// </returns>
+        [Obsolete]
         Task<(ProofMessage, ProofRecord)> CreateProofAsync(IAgentContext agentContext, string proofRequestId,
+            RequestedCredentials requestedCredentials);
+
+        Task<(PresentationMessage, ProofRecord)> CreatePresentationAsync(
+            IAgentContext agentContext, 
+            string proofRecordId,
             RequestedCredentials requestedCredentials);
 
         /// <summary>
@@ -83,16 +109,16 @@ namespace AgentFramework.Core.Contracts
         /// </summary>
         /// <returns>The proof.</returns>
         /// <param name="agentContext">Agent Context.</param>
-        /// <param name="proofRequestId">Identifier of the proof request.</param>
-        Task RejectProofRequestAsync(IAgentContext agentContext, string proofRequestId);
+        /// <param name="proofRecordId">Identifier of the proof request.</param>
+        Task RejectProofRequestAsync(IAgentContext agentContext, string proofRecordId);
 
         /// <summary>
         /// Verifies a proof.
         /// </summary>
         /// <param name="agentContext">Agent Context.</param>
-        /// <param name="proofRecId">Identifier of the proof record.</param>
+        /// <param name="proofRecordId">Identifier of the proof record.</param>
         /// <returns>Status indicating validity of proof.</returns>
-        Task<bool> VerifyProofAsync(IAgentContext agentContext, string proofRecId);
+        Task<bool> VerifyProofAsync(IAgentContext agentContext, string proofRecordId);
 
         /// <summary>
         /// Verifies a proof.

--- a/src/AgentFramework.Core/Decorators/Signature/SignatureUtils.cs
+++ b/src/AgentFramework.Core/Decorators/Signature/SignatureUtils.cs
@@ -38,8 +38,8 @@ namespace AgentFramework.Core.Decorators.Signature
             var sigDecorator = new SignatureDecorator
             {
                 SignatureType = DefaultSignatureType,
-                SignatureData = sigData.ToBase64String(),
-                Signature = sig.ToBase64String(),
+                SignatureData = sigData.ToBase64UrlString(),
+                Signature = sig.ToBase64UrlString(),
                 Signer = signerKey
             };
 

--- a/src/AgentFramework.Core/Extensions/FormattingExtensions.cs
+++ b/src/AgentFramework.Core/Extensions/FormattingExtensions.cs
@@ -55,36 +55,21 @@ namespace AgentFramework.Core.Extensions
         /// to an equivalent 8-bit unsigned integer array.</summary>
         /// <param name="value">The value.</param>
         /// <returns></returns>
-        [Obsolete("Please use 'BytesFromBase64' or 'BytesFromBase64Url'")]
         public static byte[] GetBytesFromBase64(this string value) => Base64UrlEncoder.DecodeBytes(value);
 
         /// <summary>
-        /// Converts the specified encoded string as base-64 URL,
-        /// to an equivalent 8-bit unsigned integer array.</summary>
+        /// Converts an array of 8-bit unsigned integers to its equivalent string
+        /// representation that is encoded with base-64 digits.</summary>
         /// <param name="value">The value.</param>
         /// <returns></returns>
-        public static byte[] BytesFromBase64Url(this string value) => Base64UrlEncoder.DecodeBytes(value);
-
-        /// <summary>
-        /// Converts the specified encoded string as base-64,
-        /// to an equivalent 8-bit unsigned integer array.</summary>
-        /// <param name="value">The value.</param>
-        /// <returns></returns>
-        public static byte[] BytesFromBase64(this string value) => Convert.FromBase64String(value);
+        public static string ToBase64UrlString(this byte[] value) => Base64UrlEncoder.Encode(value);
 
         /// <summary>
         /// Converts an array of 8-bit unsigned integers to its equivalent string
         /// representation that is encoded with base-64 digits.</summary>
         /// <param name="value">The value.</param>
         /// <returns></returns>
-        public static string ToBase64String(this byte[] value) => Base64UrlEncoder.Encode(value);
-
-        /// <summary>
-        /// Converts an array of 8-bit unsigned integers to its equivalent string
-        /// representation that is encoded with base-64 digits.</summary>
-        /// <param name="value">The value.</param>
-        /// <returns></returns>
-        public static string ToBase64(this byte[] value) => Convert.ToBase64String(value);
+        public static string ToBase64String(this byte[] value) => Convert.ToBase64String(value);
 
         private static readonly JsonSerializerSettings SerializerSettings = new JsonSerializerSettings
         {

--- a/src/AgentFramework.Core/Messages/MessageType.cs
+++ b/src/AgentFramework.Core/Messages/MessageType.cs
@@ -61,6 +61,15 @@ namespace AgentFramework.Core.Messages
         /// </summary>
         public string MessageTypeUri { get; }
 
+        /// <summary>
+        /// Implcit operator that converts a string to MessageType
+        /// </summary>
+        /// <param name="value"></param>
+        public static implicit operator MessageType(string value)
+        {
+            return new MessageType(value);
+        }
+
         #region Equality methods
 
         /// <summary>

--- a/src/AgentFramework.Core/Messages/MessageTypes.cs
+++ b/src/AgentFramework.Core/Messages/MessageTypes.cs
@@ -120,5 +120,13 @@
             /// </summary>
             public const string IssueCredential = "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/issue-credential/1.0/issue-credential";
         }
+
+        public class PresentProofNames
+        {
+            public const string ProposePresentation = "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/present-proof/1.0/propose-presentation";
+            public const string RequestPresentation = "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/present-proof/1.0/request-presentation";
+            public const string Presentation = "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/present-proof/1.0/presentation";
+            public const string PresentationPreview = "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/present-proof/1.0/presentation-preview";
+        }
     }
 }

--- a/src/AgentFramework.Core/Messages/Proofs/PresentationMessage.cs
+++ b/src/AgentFramework.Core/Messages/Proofs/PresentationMessage.cs
@@ -1,0 +1,37 @@
+using System;
+using AgentFramework.Core.Decorators.Attachments;
+using Newtonsoft.Json;
+
+namespace AgentFramework.Core.Messages
+{
+    /// <summary>
+    /// Proof Presentation message
+    /// </summary>
+    public class PresentationMessage : AgentMessage
+    {
+        /// <summary>
+        /// Initializes a new instace of the <see cref="PresentationMessage" /> class.
+        /// </summary>
+        public PresentationMessage()
+        {
+            Id = Guid.NewGuid().ToString();
+            Type = MessageTypes.PresentProofNames.Presentation;
+        }
+
+        /// <summary>
+        /// Gets or sets the comment.
+        /// </summary>
+        /// <value>
+        /// The comment.
+        /// </value>
+        [JsonProperty("comment", NullValueHandling = NullValueHandling.Ignore)]
+        public string Comment { get; set; }
+
+        /// <summary>
+        /// Gets or sets the request presentation attachments
+        /// </summary>
+        /// <value></value>
+        [JsonProperty("presentations~attach")]
+        public Attachment[] Presentations { get; set; }
+    }
+}

--- a/src/AgentFramework.Core/Messages/Proofs/ProofMessage.cs
+++ b/src/AgentFramework.Core/Messages/Proofs/ProofMessage.cs
@@ -6,6 +6,7 @@ namespace AgentFramework.Core.Messages.Proofs
     /// <summary>
     /// A proof content message.
     /// </summary>
+    [Obsolete]
     public class ProofMessage : AgentMessage
     {
         /// <inheritdoc />

--- a/src/AgentFramework.Core/Messages/Proofs/ProofRequestMessage.cs
+++ b/src/AgentFramework.Core/Messages/Proofs/ProofRequestMessage.cs
@@ -6,6 +6,7 @@ namespace AgentFramework.Core.Messages.Proofs
     /// <summary>
     /// A proof request content message.
     /// </summary>
+    [Obsolete]
     public class ProofRequestMessage : AgentMessage
     {
         /// <inheritdoc />

--- a/src/AgentFramework.Core/Messages/Proofs/RequestPresentationMessage.cs
+++ b/src/AgentFramework.Core/Messages/Proofs/RequestPresentationMessage.cs
@@ -1,0 +1,37 @@
+using System;
+using AgentFramework.Core.Decorators.Attachments;
+using Newtonsoft.Json;
+
+namespace AgentFramework.Core.Messages
+{
+    /// <summary>
+    /// Request presentation message
+    /// </summary>
+    public class RequestPresentationMessage : AgentMessage
+    {
+        /// <summary>
+        /// Initializes a new instace of the <see cref="RequestPresentationMessage" /> class.
+        /// </summary>
+        public RequestPresentationMessage()
+        {
+            Id = Guid.NewGuid().ToString();
+            Type = MessageTypes.PresentProofNames.RequestPresentation;
+        }
+
+        /// <summary>
+        /// Gets or sets the comment.
+        /// </summary>
+        /// <value>
+        /// The comment.
+        /// </value>
+        [JsonProperty("comment", NullValueHandling = NullValueHandling.Ignore)]
+        public string Comment { get; set; }
+
+        /// <summary>
+        /// Gets or sets the request presentation attachments
+        /// </summary>
+        /// <value></value>
+        [JsonProperty("request_presentations~attach")]
+        public Attachment[] Requests { get; set; }
+    }
+}

--- a/src/AgentFramework.Core/Runtime/DefaultCredentialService.cs
+++ b/src/AgentFramework.Core/Runtime/DefaultCredentialService.cs
@@ -478,5 +478,20 @@ namespace AgentFramework.Core.Runtime
             // Update local credential record
             await RecordService.UpdateAsync(agentContext.Wallet, credential);
         }
+
+        /// <inheritdoc />
+        public async Task DeleteCredentialAsync(IAgentContext agentContext, string credentialId)
+        {
+            var credentialRecord = await GetAsync(agentContext, credentialId);
+            try
+            {
+                await AnonCreds.ProverDeleteCredentialAsync(agentContext.Wallet, credentialRecord.CredentialId);
+            }
+            catch
+            {
+                // OK
+            }
+            await RecordService.DeleteAsync<CredentialRecord>(agentContext.Wallet, credentialId);
+        }
     }
 }

--- a/src/AgentFramework.Core/Runtime/DefaultCredentialServiceV1.cs
+++ b/src/AgentFramework.Core/Runtime/DefaultCredentialServiceV1.cs
@@ -30,7 +30,7 @@ namespace AgentFramework.Core.Runtime
             var offerAttachment = credentialOffer.Offers.FirstOrDefault(x => x.Id == "libindy-cred-offer-0")
                 ?? throw new ArgumentNullException(nameof(CredentialOfferMessage.Offers));
 
-            var offerJson = offerAttachment.Data.Base64.BytesFromBase64().GetUTF8String();
+            var offerJson = offerAttachment.Data.Base64.GetBytesFromBase64().GetUTF8String();
             var offer = JObject.Parse(offerJson);
             var definitionId = offer["cred_def_id"].ToObject<string>();
             var schemaId = offer["schema_id"].ToObject<string>();
@@ -94,16 +94,21 @@ namespace AgentFramework.Core.Runtime
             var threadId = credential.GetTag(TagConstants.LastThreadId);
             var response = new CredentialRequestMessage
             {
-                Requests = new[] { 
+                // The comment was required by Aca-py, even though it is declared optional in RFC-0036
+                // Was added for interoperability
+                Comment = "",
+                Requests = new[]
+                { 
                     new Attachment
-                {
-                    Id = "libindy-cred-request-0",
-                    MimeType = CredentialMimeTypes.ApplicationJsonMimeType,
-                    Data = new AttachmentContent
                     {
-                        Base64 = request.CredentialRequestJson.GetUTF8Bytes().ToBase64()
+                        Id = "libindy-cred-request-0",
+                        MimeType = CredentialMimeTypes.ApplicationJsonMimeType,
+                        Data = new AttachmentContent
+                        {
+                            Base64 = request.CredentialRequestJson.GetUTF8Bytes().ToBase64String()
+                        }
                     }
-                } }
+                }
             };
 
             response.ThreadFrom(threadId);
@@ -115,7 +120,7 @@ namespace AgentFramework.Core.Runtime
             var credentialAttachment = credential.Credentials.FirstOrDefault(x => x.Id == "libindy-cred-0")
                 ?? throw new ArgumentException("Credential attachment not found");
 
-            var credentialJson = credentialAttachment.Data.Base64.BytesFromBase64().GetUTF8String();
+            var credentialJson = credentialAttachment.Data.Base64.GetBytesFromBase64().GetUTF8String();
             var credentialJobj = JObject.Parse(credentialJson);
             var definitionId = credentialJobj["cred_def_id"].ToObject<string>();
             var revRegId = credentialJobj["rev_reg_id"]?.ToObject<string>();
@@ -227,7 +232,7 @@ namespace AgentFramework.Core.Runtime
                         MimeType = CredentialMimeTypes.ApplicationJsonMimeType,
                         Data = new AttachmentContent
                         {
-                            Base64 = offerJson.GetUTF8Bytes().ToBase64()
+                            Base64 = offerJson.GetUTF8Bytes().ToBase64String()
                         }
                     }
                 },
@@ -257,7 +262,7 @@ namespace AgentFramework.Core.Runtime
                 throw new AgentFrameworkException(ErrorCode.RecordInInvalidState,
                     $"Credential state was invalid. Expected '{CredentialState.Offered}', found '{credential.State}'");
 
-            credential.RequestJson = credentialAttachment.Data.Base64.BytesFromBase64().GetUTF8String();
+            credential.RequestJson = credentialAttachment.Data.Base64.GetBytesFromBase64().GetUTF8String();
             credential.ConnectionId = connection.Id;
 
             await credential.TriggerAsync(CredentialTrigger.Request);
@@ -350,7 +355,7 @@ namespace AgentFramework.Core.Runtime
                         {
                             Base64 = issuedCredential.CredentialJson
                                 .GetUTF8Bytes()
-                                .ToBase64()
+                                .ToBase64String()
                         }
                     }
                 }

--- a/src/AgentFramework.Core/Runtime/DefaultLedgerService.cs
+++ b/src/AgentFramework.Core/Runtime/DefaultLedgerService.cs
@@ -63,58 +63,6 @@ namespace AgentFramework.Core.Runtime
         }
 
         /// <inheritdoc />
-        public async Task<IndyTaa> LookupTaaAsync(IAgentContext context, string data = null)
-        {
-            IndyTaa ParseTaa(string response)
-            {
-                var jresponse = JObject.Parse(response);
-                if (jresponse["result"]["data"].HasValues)
-                {
-                    return new IndyTaa
-                    {
-                        Text = jresponse["result"]["data"]["text"].ToString(),
-                        Version = jresponse["result"]["data"]["version"].ToString()
-                    };
-                }
-                return null;
-            };
-
-            var req = await Ledger.BuildGetTxnAuthorAgreementRequestAsync(null, data);
-            var res = await Ledger.SubmitRequestAsync(await context.Pool, req);
-
-            EnsureSuccessResponse(res);
-
-            return ParseTaa(res);
-        }
-
-        /// <inheritdoc />
-        public virtual async Task<IndyAml> LookupAmlAsync(
-            IAgentContext context, 
-            DateTimeOffset timestamp = default(DateTimeOffset), 
-            string version = null)
-        {
-            IndyAml ParseAml(string response)
-            {
-                var jresponse = JObject.Parse(response);
-                if (jresponse["result"]["data"].HasValues)
-                {
-                    return jresponse["result"]["data"].ToObject<IndyAml>();
-                }
-                return null;
-            };
-
-            var req = await Ledger.BuildGetAcceptanceMechanismsRequestAsync(
-                null, 
-                timestamp == DateTimeOffset.MinValue ? -1 : timestamp.ToUnixTimeSeconds(),
-                version);
-            var res = await Ledger.SubmitRequestAsync(await context.Pool, req);
-
-            EnsureSuccessResponse(res);
-
-            return ParseAml(res);
-        }
-
-        /// <inheritdoc />
         public virtual async Task<ParseRegistryResponseResult> LookupRevocationRegistryDeltaAsync(Pool pool, string revocationRegistryId,
              long from, long to)
         {

--- a/src/AgentFramework.Core/Runtime/DefaultPoolService.cs
+++ b/src/AgentFramework.Core/Runtime/DefaultPoolService.cs
@@ -1,8 +1,13 @@
-﻿using System.Collections.Concurrent;
+﻿using System;
+using System.Collections.Concurrent;
 using System.Threading.Tasks;
 using AgentFramework.Core.Contracts;
+using AgentFramework.Core.Exceptions;
 using AgentFramework.Core.Extensions;
+using AgentFramework.Core.Models.Ledger;
+using Hyperledger.Indy.LedgerApi;
 using Hyperledger.Indy.PoolApi;
+using Newtonsoft.Json.Linq;
 
 namespace AgentFramework.Core.Runtime
 {
@@ -12,6 +17,12 @@ namespace AgentFramework.Core.Runtime
         /// <summary>Collection of active pool handles.</summary>
         protected static readonly ConcurrentDictionary<string, Pool> Pools =
             new ConcurrentDictionary<string, Pool>();
+
+        protected static readonly ConcurrentDictionary<string, IndyTaa> Taas =
+            new ConcurrentDictionary<string, IndyTaa>();
+
+        protected static readonly ConcurrentDictionary<string, IndyAml> Amls =
+            new ConcurrentDictionary<string, IndyAml>();
 
         /// <inheritdoc />
         public virtual async Task<Pool> GetPoolAsync(string poolName, int protocolVersion)
@@ -40,6 +51,79 @@ namespace AgentFramework.Core.Runtime
             var poolConfig = new {genesis_txn = genesisFile}.ToJson();
 
             await Pool.CreatePoolLedgerConfigAsync(poolName, poolConfig);
+        }
+
+        /// <inheritdoc />
+        public async Task<IndyTaa> GetTaaAsync(string poolName)
+        {
+            IndyTaa ParseTaa(string response)
+            {
+                var jresponse = JObject.Parse(response);
+                if (jresponse["result"]["data"].HasValues)
+                {
+                    return new IndyTaa
+                    {
+                        Text = jresponse["result"]["data"]["text"].ToString(),
+                        Version = jresponse["result"]["data"]["version"].ToString()
+                    };
+                }
+                return null;
+            };
+
+            if (Taas.TryGetValue(poolName, out var taa))
+            {
+                return taa;
+            }
+
+            var pool = await GetPoolAsync(poolName, 2);
+            var req = await Ledger.BuildGetTxnAuthorAgreementRequestAsync(null, null);
+            var res = await Ledger.SubmitRequestAsync(pool, req);
+
+            EnsureSuccessResponse(res);
+
+            taa = ParseTaa(res);
+            Taas.TryAdd(poolName, taa);
+            return taa;
+        }
+
+        void EnsureSuccessResponse(string res)
+        {
+            var response = JObject.Parse(res);
+
+            if (!response["op"].ToObject<string>().Equals("reply", StringComparison.OrdinalIgnoreCase))
+                throw new AgentFrameworkException(ErrorCode.LedgerOperationRejected, "Ledger operation rejected");
+        }
+
+        /// <inheritdoc />
+        public async Task<IndyAml> GetAmlAsync(string poolName, DateTimeOffset timestamp = default(DateTimeOffset), string version = null)
+        {
+            IndyAml ParseAml(string response)
+            {
+                var jresponse = JObject.Parse(response);
+                if (jresponse["result"]["data"].HasValues)
+                {
+                    return jresponse["result"]["data"].ToObject<IndyAml>();
+                }
+                return null;
+            };
+
+            if (Amls.TryGetValue(poolName, out var aml))
+            {
+                return aml;
+            }
+
+            var pool = await GetPoolAsync(poolName, 2);
+            var req = await Ledger.BuildGetAcceptanceMechanismsRequestAsync(
+                submitter_did: null,
+                timestamp: timestamp == DateTimeOffset.MinValue ? -1 : timestamp.ToUnixTimeSeconds(),
+                version: version);
+            var res = await Ledger.SubmitRequestAsync(pool, req);
+
+            EnsureSuccessResponse(res);
+
+            aml = ParseAml(res);
+            Amls.TryAdd(poolName, aml);
+            return aml;
         }
     }
 }

--- a/test/AgentFramework.Core.Tests/LerdgerTests.cs
+++ b/test/AgentFramework.Core.Tests/LerdgerTests.cs
@@ -16,11 +16,11 @@ namespace AgentFramework.Core.Tests
         [Fact(DisplayName = "Get Transaction Author Agreement from ledger if exists")]
         public async Task GetTaaFromLedger()
         {
-            var taa = await Host.Services.GetService<ILedgerService>()
-                .LookupTaaAsync(Context);
+            var taa = await Host.Services.GetService<IPoolService>()
+                .GetTaaAsync(GetPoolName());
 
-            var aml = await Host.Services.GetService<ILedgerService>()
-                .LookupAmlAsync(Context);
+            var aml = await Host.Services.GetService<IPoolService>()
+                .GetAmlAsync(GetPoolName());
 
             Assert.True(true);
         }
@@ -28,8 +28,8 @@ namespace AgentFramework.Core.Tests
         [Fact(DisplayName = "Get Acceptance Mechanisms List from ledger if exists")]
         public async Task GetAmlFromLedger()
         {
-            var aml = await Host.Services.GetService<ILedgerService>()
-                .LookupAmlAsync(Context);
+            var aml = await Host.Services.GetService<IPoolService>()
+                .GetAmlAsync(GetPoolName());
 
             Assert.True(true);
         }

--- a/test/AgentFramework.Core.Tests/Protocols/CredentialTests.cs
+++ b/test/AgentFramework.Core.Tests/Protocols/CredentialTests.cs
@@ -92,9 +92,9 @@ namespace AgentFramework.Core.Tests.Protocols
         {
             var events = 0;
             _eventAggregator.GetEventByType<ServiceMessageProcessingEvent>()
-                .Where(_ => (_.MessageType == MessageTypes.CredentialOffer ||
-                             _.MessageType == MessageTypes.CredentialRequest ||
-                             _.MessageType == MessageTypes.Credential))
+                .Where(_ => (_.MessageType == MessageTypes.IssueCredentialNames.OfferCredential ||
+                             _.MessageType == MessageTypes.IssueCredentialNames.RequestCredential ||
+                             _.MessageType == MessageTypes.IssueCredentialNames.IssueCredential))
                 .Subscribe(_ =>
                 {
                     events++;

--- a/test/AgentFramework.Core.Tests/Protocols/ProofTests.cs
+++ b/test/AgentFramework.Core.Tests/Protocols/ProofTests.cs
@@ -101,8 +101,8 @@ namespace AgentFramework.Core.Tests.Protocols
         {
             var events = 0;
             _eventAggregator.GetEventByType<ServiceMessageProcessingEvent>()
-                .Where(_ => (_.MessageType == MessageTypes.ProofRequest ||
-                             _.MessageType == MessageTypes.DisclosedProof))
+                .Where(_ => (_.MessageType == MessageTypes.PresentProofNames.RequestPresentation ||
+                             _.MessageType == MessageTypes.PresentProofNames.Presentation))
                 .Subscribe(_ =>
                 {
                     events++;


### PR DESCRIPTION
- Added Presentation Protocol v1. Old methods and models are marked Obsolete and will be removed soon.
- Moved Taa and Aml into Pool Service and added caching logic. Their values will be fetched from ledger only once per service lifetime.
- Updated Base64 extensions encoding to bring the codebase in line with the Aries RFC 0036
- Updated unit tests to test against Issue and Proof protocols v1