### PR TITLE
Credential attribute preview parsing fix

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
  <PropertyGroup>
-   <Version>1.0.1</Version>
+   <Version>1.0.2</Version>
    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Company>Hyperledger</Company>
     <Authors>Hyperledger Aries Dotnet Maintainers</Authors>

--- a/src/Hyperledger.Aries/Agents/DefaultAgent.cs
+++ b/src/Hyperledger.Aries/Agents/DefaultAgent.cs
@@ -21,7 +21,12 @@ namespace Hyperledger.Aries.Agents
         protected override void ConfigureHandlers()
         {
             AddConnectionHandler();
+            AddCredentialHandler();
+            AddProofHandler();
+            AddDiscoveryHandler();
+            AddBasicMessageHandler();
             AddForwardHandler();
+            AddTrustPingHandler();
         }
     }
 }

--- a/src/Hyperledger.Aries/Features/IssueCredential/Models/CredentialPreviewAttributeConverter.cs
+++ b/src/Hyperledger.Aries/Features/IssueCredential/Models/CredentialPreviewAttributeConverter.cs
@@ -23,7 +23,7 @@ namespace Hyperledger.Aries.Features.IssueCredential
 
             var obj = new CredentialPreviewAttribute();
             obj.Name = name.Value<string>();
-            obj.MimeType = mimeType.HasValues ? mimeType.Value<string>() : CredentialMimeTypes.TextMimeType;
+            obj.MimeType = mimeType?.Value<string>();
             obj.Value = CredentialUtils.CastAttribute(value, obj.MimeType);
             return obj;
         }

--- a/src/Hyperledger.Aries/Utils/CredentialUtils.cs
+++ b/src/Hyperledger.Aries/Utils/CredentialUtils.cs
@@ -55,6 +55,7 @@ namespace Hyperledger.Aries.Utils
         {
             switch (attribute.MimeType)
             {
+                case null:
                 case CredentialMimeTypes.TextMimeType:
                 case CredentialMimeTypes.ApplicationJsonMimeType:
                     break;
@@ -115,6 +116,8 @@ namespace Hyperledger.Aries.Utils
         {
             switch (mimeType)
             {
+                case null:
+                    return attributeValue.Value<string>();
                 case CredentialMimeTypes.TextMimeType:
                 case CredentialMimeTypes.ApplicationJsonMimeType:
                     return attributeValue.Value<string>();

--- a/test/Hyperledger.Aries.Tests/ConverterTests.cs
+++ b/test/Hyperledger.Aries.Tests/ConverterTests.cs
@@ -40,7 +40,7 @@ namespace Hyperledger.Aries.Tests
             Assert.Equal("123", decorator.Prop1);
         }
 
-        [Fact]
+        [Fact(DisplayName = "Decode credential preview attribute with null mime-type")]
         public void DecodeCredentialPreviewAttribute()
         {
             var json = new { name = "some name", value = "some value" }.ToJson();
@@ -48,6 +48,9 @@ namespace Hyperledger.Aries.Tests
             var attr = JsonConvert.DeserializeObject<CredentialPreviewAttribute>(json);
 
             Assert.NotNull(attr);
+            Assert.Equal("some name", attr.Name);
+            Assert.Equal("some value", attr.Value);
+            Assert.Null(attr.MimeType);
         }
     }
 

--- a/test/Hyperledger.Aries.Tests/ConverterTests.cs
+++ b/test/Hyperledger.Aries.Tests/ConverterTests.cs
@@ -4,6 +4,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Xunit;
 using Hyperledger.Aries.Agents;
+using Hyperledger.Aries.Features.IssueCredential;
 
 namespace Hyperledger.Aries.Tests
 {
@@ -37,6 +38,16 @@ namespace Hyperledger.Aries.Tests
             Assert.NotNull(decorator);
             Assert.IsType<SampleDecorator>(decorator);
             Assert.Equal("123", decorator.Prop1);
+        }
+
+        [Fact]
+        public void DecodeCredentialPreviewAttribute()
+        {
+            var json = new { name = "some name", value = "some value" }.ToJson();
+
+            var attr = JsonConvert.DeserializeObject<CredentialPreviewAttribute>(json);
+
+            Assert.NotNull(attr);
         }
     }
 

--- a/test/Hyperledger.Aries.Tests/Protocols/CredentialUtilsTests.cs
+++ b/test/Hyperledger.Aries.Tests/Protocols/CredentialUtilsTests.cs
@@ -61,8 +61,8 @@ namespace Hyperledger.Aries.Tests.Protocols
 
             attributeValue.MimeType = null;
 
-            var ex = Assert.Throws<AriesFrameworkException>(() => CredentialUtils.ValidateCredentialPreviewAttribute(attributeValue));
-            Assert.True(ex.ErrorCode == ErrorCode.InvalidParameterFormat);
+            CredentialUtils.ValidateCredentialPreviewAttribute(attributeValue);
+            Assert.True(true);
         }
 
         [Fact]


### PR DESCRIPTION
Signed-off-by: Tomislav Markovski <tmarkovski@gmail.com>

Modify the expectation that `mime-type` won't be supplied with credential attribute and may be null. Will be treated as string as described in [Mime Type and Value](https://github.com/hyperledger/aries-rfcs/tree/master/features/0036-issue-credential#mime-type-and-value) in RFC 0036