### PR TITLE
Fix of tailsLocation issue with query parameters

### DIFF
--- a/src/Hyperledger.Aries/Features/IssueCredential/DefaultSchemaService.cs
+++ b/src/Hyperledger.Aries/Features/IssueCredential/DefaultSchemaService.cs
@@ -198,7 +198,7 @@ namespace Hyperledger.Aries.Features.IssueCredential
                 if (tailsBaseUri != null)
                 {
                     var tailsfile = Path.GetFileName(revocationDefinition["value"]["tailsLocation"].ToObject<string>());
-                    revocationDefinition["value"]["tailsLocation"] = new Uri(tailsBaseUri, tailsfile).ToString();
+                    revocationDefinition["value"]["tailsLocation"] = new Uri(tailsBaseUri + tailsfile).ToString();
                     revocationRecord.TailsFile = tailsfile;
                 }
 

--- a/src/Hyperledger.Aries/Features/IssueCredential/DefaultTailsService.cs
+++ b/src/Hyperledger.Aries/Features/IssueCredential/DefaultTailsService.cs
@@ -80,8 +80,14 @@ namespace Hyperledger.Aries.Features.IssueCredential
             var revocationRegistry =
                 await LedgerService.LookupRevocationRegistryDefinitionAsync(pool, revocationRegistryId);
             var tailsUri = JObject.Parse(revocationRegistry.ObjectJson)["value"]["tailsLocation"].ToObject<string>();
+            var tailsFileName = JObject.Parse(revocationRegistry.ObjectJson)["value"]["tailsHash"].ToObject<string>();
 
-            var tailsfile = Path.Combine(EnvironmentUtils.GetTailsPath(), new Uri(tailsUri).Segments.Last());
+            var tailsfile = Path.Combine(EnvironmentUtils.GetTailsPath(), tailsFileName);
+
+            if (!Directory.Exists(EnvironmentUtils.GetTailsPath()))
+            {
+                Directory.CreateDirectory(EnvironmentUtils.GetTailsPath());
+            }
 
             if (!File.Exists(tailsfile))
             {


### PR DESCRIPTION
#### Short description of what this resolves:
When calling new Uri(tailsBaseUri, tailsfile) when the tailsBaseUri had some additional query parameters, these parameters got lost.

#### Changes proposed in this pull request:
Changed new Uri(tailsBaseUri, tailsfile) to new Uri(tailsBaseUri + tailsfile).

**Fixes**: 
Now all query parameters stay in the tailsLocation.
