### PR TITLE
Changing self attested attribute value type to string

### DIFF
--- a/src/Hyperledger.Aries/Features/PresentProof/Models/RequestedProof.cs
+++ b/src/Hyperledger.Aries/Features/PresentProof/Models/RequestedProof.cs
@@ -24,6 +24,6 @@ namespace Hyperledger.Aries.Features.PresentProof
         /// The revealed attributes.
         /// </value>
         [JsonProperty("self_attested_attrs")]
-        public Dictionary<string, ProofAttribute> SelfAttestedAttributes { get; set; }
+        public Dictionary<string, string> SelfAttestedAttributes { get; set; }
     }
 }


### PR DESCRIPTION
#### Short description of what this resolves:
Getting an error parsing a Proof when self attested attributes are set. The value of a self attested attribute in a requested_proof should parse to the string type.

[JSON format reference](https://github.com/hyperledger/indy-sdk/blob/master/libindy/src/api/anoncreds.rs#L2102)

#### Changes proposed in this pull request:

- Changing the type of the SelfAttestedAttributes property from `Dictionary<string, ProofAttribute>` to `Dictionary<string, string>`