### PR TITLE
Update forward message format based on RFC. Mediator middleware fix (#37)

### DIFF
--- a/src/Hyperledger.Aries.Routing.Mediator/Handlers/MediatorForwardHandler.cs
+++ b/src/Hyperledger.Aries.Routing.Mediator/Handlers/MediatorForwardHandler.cs
@@ -2,7 +2,6 @@
 using System.Threading.Tasks;
 using Hyperledger.Aries.Agents;
 using Hyperledger.Aries.Contracts;
-using Hyperledger.Aries.Extensions;
 using Hyperledger.Aries.Features.Routing;
 using Hyperledger.Aries.Routing;
 using Hyperledger.Aries.Storage;
@@ -46,7 +45,7 @@ namespace Hyperledger.Aries.Routing
 
             var edgeWallet = await walletService.GetWalletAsync(inboxRecord.WalletConfiguration, inboxRecord.WalletCredentials);
 
-            var inboxItemRecord = new InboxItemRecord { ItemData = message.Message.ToJson() };
+            var inboxItemRecord = new InboxItemRecord { ItemData = message.Message };
             await recordService.AddAsync(edgeWallet, inboxItemRecord);
 
             eventAggregator.Publish(new InboxItemEvent

--- a/src/Hyperledger.Aries/Features/Routing/DefaultForwardHandler.cs
+++ b/src/Hyperledger.Aries/Features/Routing/DefaultForwardHandler.cs
@@ -1,6 +1,5 @@
 ﻿using System.Threading.Tasks;
 using Hyperledger.Aries.Agents;
-using Hyperledger.Aries.Extensions;
 using Hyperledger.Aries.Features.DidExchange;
 
 namespace Hyperledger.Aries.Features.Routing
@@ -19,7 +18,7 @@ namespace Hyperledger.Aries.Features.Routing
             var connectionRecord = await _connectionService.ResolveByMyKeyAsync(agentContext, message.To);
 
             if (agentContext is AgentContext context)
-                context.AddNext(new PackedMessageContext(message.Message.ToJson(), connectionRecord));
+                context.AddNext(new PackedMessageContext(message.Message, connectionRecord));
 
             return null;
         }

--- a/src/Hyperledger.Aries/Features/Routing/ForwardMessage.cs
+++ b/src/Hyperledger.Aries/Features/Routing/ForwardMessage.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Hyperledger.Aries.Agents;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace Hyperledger.Aries.Features.Routing
 {
@@ -33,6 +32,14 @@ namespace Hyperledger.Aries.Features.Routing
         /// The content.
         /// </value>
         [JsonProperty("msg")]
-        public JObject Message { get; set; }
+        public string Message { get; set; }
+
+        /// <inheritdoc />
+        public override string ToString() =>
+            $"{GetType().Name}: " +
+            $"Id={Id}, " +
+            $"Type={Type}, " +
+            $"To={To}, " +
+            $"Message={(Message?.Length > 0 ? "[hidden]" : null)}";
     }
 }

--- a/src/Hyperledger.Aries/Utils/CryptoUtils.cs
+++ b/src/Hyperledger.Aries/Utils/CryptoUtils.cs
@@ -9,7 +9,6 @@ using Hyperledger.Aries.Features.Routing;
 using Hyperledger.Indy.CryptoApi;
 using Hyperledger.Indy.WalletApi;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace Hyperledger.Aries.Utils
 {
@@ -130,7 +129,7 @@ namespace Hyperledger.Aries.Utils
                 foreach (var routingKey in routingKeys)
                 {
                     // Anonpack
-                    msg = await CryptoUtils.PackAsync(wallet, routingKey, new ForwardMessage { Message = JObject.Parse(msg.GetUTF8String()), To = previousKey });
+                    msg = await CryptoUtils.PackAsync(wallet, routingKey, new ForwardMessage { Message = msg.GetUTF8String(), To = previousKey });
                     previousKey = routingKey;
                 }
             }

--- a/test/Hyperledger.Aries.Tests/MessageServiceTests.cs
+++ b/test/Hyperledger.Aries.Tests/MessageServiceTests.cs
@@ -214,7 +214,7 @@ namespace Hyperledger.Aries.Tests
             Assert.True(unpackRes.RecipientVerkey == routingRecipient.VerKey);
             Assert.Equal(recipient.VerKey, unpackMsg.To);
 
-            var unpackRes1 = await CryptoUtils.UnpackAsync(_wallet, unpackMsg.Message.ToJson().GetUTF8Bytes());
+            var unpackRes1 = await CryptoUtils.UnpackAsync(_wallet, unpackMsg.Message.GetUTF8Bytes());
             var unpackMsg1 = JsonConvert.DeserializeObject<ConnectionInvitationMessage>(unpackRes1.Message);
 
             Assert.NotNull(unpackMsg1);
@@ -259,7 +259,7 @@ namespace Hyperledger.Aries.Tests
             Assert.True(unpackRes.RecipientVerkey == routingRecipient.VerKey);
             Assert.Equal(recipient.VerKey, unpackMsg.To);
 
-            var unpackRes1 = await CryptoUtils.UnpackAsync(_wallet, unpackMsg.Message.ToJson().GetUTF8Bytes());
+            var unpackRes1 = await CryptoUtils.UnpackAsync(_wallet, unpackMsg.Message.GetUTF8Bytes());
             var unpackMsg1 = JsonConvert.DeserializeObject<ConnectionInvitationMessage>(unpackRes1.Message);
 
             Assert.NotNull(unpackMsg1);


### PR DESCRIPTION
Reverting forward change for now. Will add later when mobile implementations are in production.

Signed-off-by: Tomislav Markovski <tmarkovski@gmail.com>
