### PR TITLE
MediatorForwardHandler: Refer to ItemRecord Id instead of InboxId

### DIFF
--- a/src/Hyperledger.Aries.Routing.Mediator/Handlers/MediatorForwardHandler.cs
+++ b/src/Hyperledger.Aries.Routing.Mediator/Handlers/MediatorForwardHandler.cs
@@ -52,7 +52,7 @@ namespace Hyperledger.Aries.Routing
             eventAggregator.Publish(new InboxItemEvent
             {
                 InboxId = inboxId,
-                ItemId = inboxRecord.Id
+                ItemId = inboxItemRecord.Id
             });
 
             return null;


### PR DESCRIPTION
#### Short description of what this resolves:
Fixes the `InboxItemEvent` to have the `Item`'s Id instead of the `Inbox` Id which is already represented in the `InboxId` field.