### PR TITLE
AspNetCore: Add null conditional for content-type check

### DIFF
--- a/src/Hyperledger.Aries.AspNetCore/AgentMiddleware.cs
+++ b/src/Hyperledger.Aries.AspNetCore/AgentMiddleware.cs
@@ -32,7 +32,7 @@ namespace Hyperledger.Aries.AspNetCore
         public async Task Invoke(HttpContext httpContext, IAgentProvider agentProvider)
         {
             if (!HttpMethods.IsPost(httpContext.Request.Method)
-                || !httpContext.Request.ContentType.Equals(DefaultMessageService.AgentWireMessageMimeType))
+                || !(httpContext.Request.ContentType?.Equals(DefaultMessageService.AgentWireMessageMimeType) ?? false))
             {
                 await _next(httpContext);
                 return;


### PR DESCRIPTION
#### Short description of what this resolves:
SignalR .NET clients sends an empty content-type while initiating a connection and it breaks the
middleware.

P.S. I thought about sending a PR for this upstream but a request to get this fixed in the .NET client wasn't accepted before: https://github.com/SignalR/SignalR/issues/3639.

#### Changes proposed in this pull request:
Added a null check for `Request.ContentType`