### PR TITLE
Lookup service with resilience logic, enabled manually

### DIFF
--- a/src/Hyperledger.Aries/Hyperledger.Aries.csproj
+++ b/src/Hyperledger.Aries/Hyperledger.Aries.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Polly" Version="7.2.0" />
     <PackageReference Include="Stateless" Version="4.2.1" />
     <PackageReference Include="Hyperledger.Indy.Sdk" Version="1.11.1" />
     <PackageReference Include="System.Reactive.Linq" Version="4.1.2" />

--- a/src/Hyperledger.Aries/Utils/ResilienceUtils.cs
+++ b/src/Hyperledger.Aries/Utils/ResilienceUtils.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Polly;
+
+namespace Hyperledger.Aries.Utils
+{
+    internal class ResilienceUtils
+    {
+        internal static T RetryPolicy<T, E>(Func<T> action, Func<E, bool> exceptionPredicate = null)
+            where E : Exception
+        {
+            if (Runtime.Flags.Contains(Runtime.LedgerLookupRetryFlag))
+            {
+                return Policy.Handle(exceptionPredicate)
+                    .WaitAndRetry(3, x => TimeSpan.FromSeconds(x * 2))
+                    .Execute(action);
+            }
+            return Policy.NoOp<T>().Execute(action);
+        }
+
+        internal static Task<T> RetryPolicyAsync<T, E>(Func<Task<T>> action, Func<E, bool> exceptionPredicate = null)
+            where E : Exception
+        {
+            if (Runtime.Flags.Contains(Runtime.LedgerLookupRetryFlag))
+            {
+                return Policy.Handle(exceptionPredicate)
+                    .WaitAndRetryAsync(3, x => TimeSpan.FromSeconds(x * 2))
+                    .ExecuteAsync(action);
+            }
+            return Policy.NoOpAsync<T>().ExecuteAsync(action);
+        }
+    }
+
+    /// <summary>
+    /// Runtime configuration
+    /// </summary>
+    public static class Runtime
+    {
+        internal static IReadOnlyList<string> Flags { get; set; } = new List<string>().AsReadOnly();
+
+        /// <summary>
+        /// Enables ledger lookup retry policy
+        /// </summary>
+        public const string LedgerLookupRetryFlag = "EnableLedgerLookupRetryPolicy";
+
+        /// <summary>
+        /// Sets runtime flags used to configure some services behavior.
+        /// </summary>
+        /// <param name="flags"></param>
+        public static void SetFlags(params string[] flags)
+        {
+            Flags = new List<string>(flags).AsReadOnly();
+        }
+    }
+}

--- a/test/Hyperledger.Aries.Tests/Hyperledger.Aries.Tests.csproj
+++ b/test/Hyperledger.Aries.Tests/Hyperledger.Aries.Tests.csproj
@@ -30,7 +30,6 @@
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="5.6.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.1" />
-    <PackageReference Include="Polly" Version="7.1.0" />
     <PackageReference Include="NLog.Config" Version="4.6.5" />
   </ItemGroup>
   <ItemGroup>

--- a/test/Hyperledger.Aries.Tests/Integration/CredentialTests.cs
+++ b/test/Hyperledger.Aries.Tests/Integration/CredentialTests.cs
@@ -11,6 +11,11 @@ namespace Hyperledger.Aries.Tests.Integration
 {
     public class CredentialTests : IAsyncLifetime
     {
+        static CredentialTests()
+        {
+            global::Hyperledger.Aries.Utils.Runtime.SetFlags(Hyperledger.Aries.Utils.Runtime.LedgerLookupRetryFlag);
+        }
+
         WalletConfiguration config1 = new WalletConfiguration { Id = Guid.NewGuid().ToString() };
         WalletConfiguration config2 = new WalletConfiguration { Id = Guid.NewGuid().ToString() };
         WalletCredentials cred = new WalletCredentials { Key = "2" };

--- a/test/Hyperledger.Aries.Tests/Integration/ProofTests.cs
+++ b/test/Hyperledger.Aries.Tests/Integration/ProofTests.cs
@@ -13,6 +13,11 @@ namespace Hyperledger.Aries.Tests.Integration
 {
     public class ProofTests : IAsyncLifetime
     {
+        static ProofTests()
+        {
+            global::Hyperledger.Aries.Utils.Runtime.SetFlags(Hyperledger.Aries.Utils.Runtime.LedgerLookupRetryFlag);
+        }
+
         WalletConfiguration config1 = new WalletConfiguration { Id = Guid.NewGuid().ToString() };
         WalletConfiguration config2 = new WalletConfiguration { Id = Guid.NewGuid().ToString() };
         WalletConfiguration config3 = new WalletConfiguration { Id = Guid.NewGuid().ToString() };

--- a/test/Hyperledger.Aries.Tests/Protocols/CredentialTests.cs
+++ b/test/Hyperledger.Aries.Tests/Protocols/CredentialTests.cs
@@ -28,6 +28,11 @@ namespace Hyperledger.Aries.Tests.Protocols
 {
     public class CredentialTests : IAsyncLifetime
     {
+        static CredentialTests()
+        {
+            global::Hyperledger.Aries.Utils.Runtime.SetFlags(Hyperledger.Aries.Utils.Runtime.LedgerLookupRetryFlag);
+        }
+
         private readonly string _issuerConfig = $"{{\"id\":\"{Guid.NewGuid()}\"}}";
         private readonly string _holderConfig = $"{{\"id\":\"{Guid.NewGuid()}\"}}";
         private const string Credentials = "{\"key\":\"test_wallet_key\"}";

--- a/test/Hyperledger.Aries.Tests/Protocols/CredentialTransientTests.cs
+++ b/test/Hyperledger.Aries.Tests/Protocols/CredentialTransientTests.cs
@@ -13,6 +13,11 @@ namespace Hyperledger.Aries.Tests.Protocols
 {
     public class CredentialTransientTests : TestSingleWallet
     {
+        static CredentialTransientTests()
+        {
+            global::Hyperledger.Aries.Utils.Runtime.SetFlags(Hyperledger.Aries.Utils.Runtime.LedgerLookupRetryFlag);
+        }
+
         [Fact(DisplayName = "Issue credential over connectionless transport using protocol v1")]
         public async Task IssueCredentialOverConnectionlessTransport()
         {

--- a/test/Hyperledger.Aries.Tests/Protocols/ProofTests.cs
+++ b/test/Hyperledger.Aries.Tests/Protocols/ProofTests.cs
@@ -28,6 +28,11 @@ namespace Hyperledger.Aries.Tests.Protocols
 {
     public class ProofTests : IAsyncLifetime
     {
+        static ProofTests()
+        {
+            global::Hyperledger.Aries.Utils.Runtime.SetFlags(Hyperledger.Aries.Utils.Runtime.LedgerLookupRetryFlag);
+        }
+
         private readonly string IssuerConfig = $"{{\"id\":\"{Guid.NewGuid()}\"}}";
         private readonly string HolderConfig = $"{{\"id\":\"{Guid.NewGuid()}\"}}";
         private readonly string RequestorConfig = $"{{\"id\":\"{Guid.NewGuid()}\"}}";


### PR DESCRIPTION
Added retry policy to lookup schema and credential definitions to fix ledger race condition.
This feature must be enabled manually using `Runtime.SetFlags`

Fixes #45 

Signed-off-by: Tomislav Markovski <tmarkovski@gmail.com>
