### PR TITLE
Changing the type of the PredicateValue in ProofPredicateInfo to int

### DIFF
--- a/src/Hyperledger.Aries/Features/PresentProof/Models/ProofPredicateInfo.cs
+++ b/src/Hyperledger.Aries/Features/PresentProof/Models/ProofPredicateInfo.cs
@@ -17,7 +17,7 @@ namespace Hyperledger.Aries.Features.PresentProof
         /// </summary>
         /// <value>The predicate value.</value>
         [JsonProperty("p_value")]
-        public string PredicateValue { get; set; }
+        public int PredicateValue { get; set; }
         
         /// <inheritdoc />
         public override string ToString() =>


### PR DESCRIPTION
#### Short description of what this resolves:
Now, it's getting the parsing error when you create presentation if predicates are set in the proof request. The p_value of the predicate info should parse to the int type. (The Indy SDK supports only numeric comparisons for predicates)

#### Changes proposed in this pull request:

- Changing the type of the PredicateValue from string to int
