### PR TITLE
Agent endpoint deserializer to support multiple serialized formats

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
  <PropertyGroup>
-   <Version>1.1.2</Version>
+   <Version>1.1.3</Version>
    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Company>Hyperledger</Company>
     <Authors>Hyperledger Aries Dotnet Maintainers</Authors>

--- a/src/Hyperledger.Aries/Agents/Converters/AgentEndpointJsonConverter.cs
+++ b/src/Hyperledger.Aries/Agents/Converters/AgentEndpointJsonConverter.cs
@@ -8,17 +8,18 @@ namespace Hyperledger.Aries.Agents
     {
         public override AgentEndpoint ReadJson(JsonReader reader, Type objectType, AgentEndpoint existingValue, bool hasExistingValue, JsonSerializer serializer)
         {
-            existingValue ??= new AgentEndpoint();
-
             var items = JObject.Load(reader);
+
+            existingValue ??= new AgentEndpoint();
+            existingValue.Did = items["did"]?.ToString();
+            existingValue.Uri = items["uri"]?.ToString();
+
             if (items["verkey"] is JArray)
             {
                 serializer.Populate(items.CreateReader(), existingValue);
                 return existingValue;
             }
 
-            existingValue.Did = items["did"]?.ToString();
-            existingValue.Uri = items["uri"]?.ToString();
             existingValue.Verkey = items["verkey"] is null ? null : new[] { items["verkey"]?.ToString() };
             return existingValue;
         }

--- a/src/Hyperledger.Aries/Agents/Converters/AgentEndpointJsonConverter.cs
+++ b/src/Hyperledger.Aries/Agents/Converters/AgentEndpointJsonConverter.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Hyperledger.Aries.Agents
+{
+    internal class AgentEndpointJsonConverter : JsonConverter<AgentEndpoint>
+    {
+        public override AgentEndpoint ReadJson(JsonReader reader, Type objectType, AgentEndpoint existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            existingValue ??= new AgentEndpoint();
+
+            var items = JObject.Load(reader);
+            if (items["verkey"] is JArray)
+            {
+                serializer.Populate(items.CreateReader(), existingValue);
+                return existingValue;
+            }
+
+            existingValue.Did = items["did"]?.ToString();
+            existingValue.Uri = items["uri"]?.ToString();
+            existingValue.Verkey = items["verkey"] is null ? null : new[] { items["verkey"]?.ToString() };
+            return existingValue;
+        }
+
+        public override bool CanWrite => false;
+        public override void WriteJson(JsonWriter writer, AgentEndpoint value, JsonSerializer serializer) => throw new NotImplementedException();
+    }
+}

--- a/src/Hyperledger.Aries/Agents/Converters/AgentMessageReader.cs
+++ b/src/Hyperledger.Aries/Agents/Converters/AgentMessageReader.cs
@@ -37,27 +37,4 @@ namespace Hyperledger.Aries.Agents
             return objectType.IsAssignableFrom(typeof(T));
         }
     }
-
-    internal class AgentMessageWriter : JsonConverter<AgentMessage>
-    {
-        public override void WriteJson(JsonWriter writer, AgentMessage value, JsonSerializer serializer)
-        {
-            var val = JObject.FromObject(value);
-            var decorators = value.GetDecorators();
-
-            foreach (var decorator in decorators)
-                val.Add(decorator.Name, decorator.Value);
-
-            serializer.Serialize(writer, val);
-        }
-
-        public override AgentMessage ReadJson(JsonReader reader, Type objectType, AgentMessage existingValue, bool hasExistingValue,
-            JsonSerializer serializer)
-        {
-            throw new NotImplementedException();
-        }
-
-        public override bool CanRead => false;
-        public override bool CanWrite => true;
-    }
 }

--- a/src/Hyperledger.Aries/Agents/Converters/AgentMessageWriter.cs
+++ b/src/Hyperledger.Aries/Agents/Converters/AgentMessageWriter.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Hyperledger.Aries.Agents
+{
+    internal class AgentMessageWriter : JsonConverter<AgentMessage>
+    {
+        public override void WriteJson(JsonWriter writer, AgentMessage value, JsonSerializer serializer)
+        {
+            var val = JObject.FromObject(value);
+            var decorators = value.GetDecorators();
+
+            foreach (var decorator in decorators)
+                val.Add(decorator.Name, decorator.Value);
+
+            serializer.Serialize(writer, val);
+        }
+
+        public override AgentMessage ReadJson(JsonReader reader, Type objectType, AgentMessage existingValue, bool hasExistingValue,
+            JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override bool CanRead => false;
+        public override bool CanWrite => true;
+    }
+}

--- a/src/Hyperledger.Aries/Common/FormattingExtensions.cs
+++ b/src/Hyperledger.Aries/Common/FormattingExtensions.cs
@@ -24,7 +24,7 @@ namespace Hyperledger.Aries.Extensions
         /// <typeparam name="T"></typeparam>
         /// <param name="array">The array.</param>
         /// <returns></returns>
-        public static T ToObject<T>(this byte[] array) => JsonConvert.DeserializeObject<T>(GetUTF8String(array));
+        public static T ToObject<T>(this byte[] array) => JsonConvert.DeserializeObject<T>(GetUTF8String(array), SerializerSettings);
 
         /// <summary>
         /// Deserializes a JSON string to object
@@ -32,7 +32,7 @@ namespace Hyperledger.Aries.Extensions
         /// <returns>The json.</returns>
         /// <param name="value">Value.</param>
         /// <typeparam name="T">The 1st type parameter.</typeparam>
-        public static T ToObject<T>(this string value) => JsonConvert.DeserializeObject<T>(value);
+        public static T ToObject<T>(this string value) => JsonConvert.DeserializeObject<T>(value, SerializerSettings);
 
         /// <summary>Encode the string into a byte array using UTF8 byte mark.</summary>
         /// <param name="value">The value.</param>
@@ -73,7 +73,11 @@ namespace Hyperledger.Aries.Extensions
 
         private static readonly JsonSerializerSettings SerializerSettings = new JsonSerializerSettings
         {
-            Converters = new List<JsonConverter> { new AgentMessageWriter() },
+            Converters = new List<JsonConverter>
+            {
+                new AgentMessageWriter(),
+                new AgentEndpointJsonConverter()
+            },
             NullValueHandling = NullValueHandling.Ignore
         };
 

--- a/src/Hyperledger.Aries/Hyperledger.Aries.csproj
+++ b/src/Hyperledger.Aries/Hyperledger.Aries.csproj
@@ -1,10 +1,16 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Description>.NET Core tools for building agent services</Description>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Hyperledger.Aries.xml</DocumentationFile>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.1" />

--- a/test/Hyperledger.Aries.Tests/ConverterTests.cs
+++ b/test/Hyperledger.Aries.Tests/ConverterTests.cs
@@ -5,6 +5,7 @@ using Newtonsoft.Json.Linq;
 using Xunit;
 using Hyperledger.Aries.Agents;
 using Hyperledger.Aries.Features.IssueCredential;
+using System.Linq;
 
 namespace Hyperledger.Aries.Tests
 {
@@ -51,6 +52,37 @@ namespace Hyperledger.Aries.Tests
             Assert.Equal("some name", attr.Name);
             Assert.Equal("some value", attr.Value);
             Assert.Null(attr.MimeType);
+        }
+
+        [Fact(DisplayName = "Deserialize agent endpoint stored as string")]
+        public void DeserializeAgentEndpointFromString()
+        {
+            var json = new { verkey = "1" }.ToJson();
+
+            var endpoint = json.ToObject<AgentEndpoint>();
+            Assert.NotNull(endpoint.Verkey);
+            Assert.NotEmpty(endpoint.Verkey);
+            Assert.Equal("1", endpoint.Verkey.First());
+        }
+
+        [Fact(DisplayName = "Deserialize agent endpoint stored as string array")]
+        public void DeserializeAgentEndpointFromStringArray()
+        {
+            var json = new { verkey = new[] { "1" } }.ToJson();
+
+            var endpoint = json.ToObject<AgentEndpoint>();
+            Assert.NotNull(endpoint.Verkey);
+            Assert.NotEmpty(endpoint.Verkey);
+            Assert.Equal("1", endpoint.Verkey.First());
+        }
+
+        [Fact(DisplayName = "Deserialize agent endpoint DID")]
+        public void DeserializeAgentEndpointDidFromString()
+        {
+            var json = new { did = "1" }.ToJson();
+
+            var endpoint = json.ToObject<AgentEndpoint>();
+            Assert.Equal("1", endpoint.Did);
         }
     }
 


### PR DESCRIPTION
Signed-off-by: Tomislav Markovski <tmarkovski@gmail.com>

This PR addresses an issue with deployed agents who have their endpoint serialized in a format to use single `verkey`, instead an array. The `verkey` array change was added recently, but it didn't provide a way for existing agents to adopt the change.