### PR TITLE
Pass wallet storage type from agent options

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
  <PropertyGroup>
-   <Version>1.1.4</Version>
+   <Version>1.1.5</Version>
    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Company>Hyperledger</Company>
     <Authors>Hyperledger Aries Dotnet Maintainers</Authors>

--- a/src/Hyperledger.Aries.Routing.Mediator/Handlers/RoutingInboxHandler.cs
+++ b/src/Hyperledger.Aries.Routing.Mediator/Handlers/RoutingInboxHandler.cs
@@ -3,9 +3,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Hyperledger.Aries.Agents;
+using Hyperledger.Aries.Configuration;
 using Hyperledger.Aries.Features.DidExchange;
 using Hyperledger.Aries.Storage;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Hyperledger.Aries.Routing
 {
@@ -14,17 +16,20 @@ namespace Hyperledger.Aries.Routing
         private readonly IWalletRecordService recordService;
         private readonly IWalletService walletService;
         private readonly IRoutingStore routingStore;
+        private readonly AgentOptions options;
         private readonly ILogger<RoutingInboxHandler> logger;
 
         public RoutingInboxHandler(
             IWalletRecordService recordService,
             IWalletService walletService,
             IRoutingStore routingStore,
+            IOptions<AgentOptions> options,
             ILogger<RoutingInboxHandler> logger)
         {
             this.recordService = recordService;
             this.walletService = walletService;
             this.routingStore = routingStore;
+            this.options = options.Value;
             this.logger = logger;
         }
 
@@ -146,7 +151,11 @@ namespace Hyperledger.Aries.Routing
             var inboxRecord = new InboxRecord
             {
                 Id = inboxId,
-                WalletConfiguration = new WalletConfiguration { Id = inboxId },
+                WalletConfiguration = new WalletConfiguration
+                {
+                    Id = inboxId,
+                    StorageType = options.WalletConfiguration?.StorageType ?? "default"
+                },
                 WalletCredentials = new WalletCredentials { Key = inboxKey }
             };
             connection.SetTag("InboxId", inboxId);


### PR DESCRIPTION
Signed-off-by: Tomislav Markovski <tmarkovski@gmail.com>

This PR addresses an issue in cases when it was not possible to create a wallet of the same storage type as the configured agent. Implementations that use custom wallet storage would always create new inbox wallet with default (sqlite) wallet.