### PR TITLE
Allow multiple registrations of device without throwing

### DIFF
--- a/src/Hyperledger.Aries.Routing.Mediator/Handlers/RoutingInboxHandler.cs
+++ b/src/Hyperledger.Aries.Routing.Mediator/Handlers/RoutingInboxHandler.cs
@@ -6,6 +6,7 @@ using Hyperledger.Aries.Agents;
 using Hyperledger.Aries.Configuration;
 using Hyperledger.Aries.Features.DidExchange;
 using Hyperledger.Aries.Storage;
+using Hyperledger.Indy.WalletApi;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -92,7 +93,17 @@ namespace Hyperledger.Aries.Routing
                 DeviceId = addDeviceInfoMessage.DeviceId,
                 DeviceVendor = addDeviceInfoMessage.DeviceVendor
             };
-            await recordService.AddAsync(agentContext.Wallet, deviceRecord);
+            try
+            {
+                await recordService.AddAsync(agentContext.Wallet, deviceRecord);
+            }
+            catch (WalletItemAlreadyExistsException)
+            {
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "Unable to register device", addDeviceInfoMessage);
+            }
         }
 
         private async Task DeleteInboxItemsAsync(IAgentContext agentContext, ConnectionRecord connection, DeleteInboxItemsMessage deleteInboxItemsMessage)


### PR DESCRIPTION
Signed-off-by: Tomislav Markovski <tmarkovski@gmail.com>

Allows edge agents to call device registration multiple times, without throwing.