### PR TITLE
Delete tags when removing a record completely

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
  <PropertyGroup>
-   <Version>1.1.8</Version>
+   <Version>1.1.9</Version>
    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Company>Hyperledger</Company>
     <Authors>Hyperledger Aries Dotnet Maintainers</Authors>

--- a/docker/web-agent.dockerfile
+++ b/docker/web-agent.dockerfile
@@ -1,7 +1,7 @@
-FROM streetcred/dotnet-indy:1.12.2 AS base
+FROM streetcred/dotnet-indy:1.14.2 AS base
 WORKDIR /app
 
-FROM streetcred/dotnet-indy:1.12.2 AS build
+FROM streetcred/dotnet-indy:1.14.2 AS build
 WORKDIR /src
 COPY [".", "."]
 


### PR DESCRIPTION
Signed-off-by: Tomislav Markovski <tmarkovski@gmail.com>

This PR adds additional cleanup of tags when deleting a record. This issue caused a bug in iOS runtime where deleting a record of certain type that had tags would prevent adding new records immediately after with record already exists exception.