### PR TITLE
Support for adding restrictions to proof requsts based on attribute value

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
  <PropertyGroup>
-   <Version>1.1.9</Version>
+   <Version>1.1.10</Version>
    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Company>Hyperledger</Company>
     <Authors>Hyperledger Aries Dotnet Maintainers</Authors>

--- a/src/Hyperledger.Aries/Common/FormattingExtensions.cs
+++ b/src/Hyperledger.Aries/Common/FormattingExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Hyperledger.Aries.Agents;
+using Hyperledger.Aries.Features.PresentProof;
 using Hyperledger.Aries.Utils;
 using Newtonsoft.Json;
 
@@ -76,7 +77,8 @@ namespace Hyperledger.Aries.Extensions
             Converters = new List<JsonConverter>
             {
                 new AgentMessageWriter(),
-                new AgentEndpointJsonConverter()
+                new AgentEndpointJsonConverter(),
+                new AttributeFilterConverter()
             },
             NullValueHandling = NullValueHandling.Ignore
         };

--- a/src/Hyperledger.Aries/Features/PresentProof/Models/AttributeFilterConverter.cs
+++ b/src/Hyperledger.Aries/Features/PresentProof/Models/AttributeFilterConverter.cs
@@ -1,0 +1,66 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+using System;
+using Newtonsoft.Json.Linq;
+using System.Text.RegularExpressions;
+
+namespace Hyperledger.Aries.Features.PresentProof
+{
+    public class AttributeFilterConverter : JsonConverter<AttributeFilter>
+    {
+        /// <summary>
+        /// Reads the JSON representation of the object.
+        /// </summary>
+        /// <param name="reader">The <see cref="T:Newtonsoft.Json.JsonReader" /> to read from.</param>
+        /// <param name="objectType">Type of the object.</param>
+        /// <param name="existingValue">The existing value of object being read. If there is no existing value then <c>null</c> will be used.</param>
+        /// <param name="hasExistingValue">The existing value has a value.</param>
+        /// <param name="serializer">The calling serializer.</param>
+        /// <returns>
+        /// The object value.
+        /// </returns>
+        public override AttributeFilter ReadJson(JsonReader reader, Type objectType, AttributeFilter existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            var items = JObject.Load(reader);
+
+            if (!hasExistingValue) existingValue = new AttributeFilter();
+
+            serializer.Populate(items.CreateReader(), existingValue);
+
+            var regex = new Regex("^attr::([^:]+)::(value)$");
+            foreach (var item in items)
+            {
+                if (regex.IsMatch(item.Key))
+                {
+                    var match = regex.Match(item.Key);
+                    existingValue.AttributeValue = new AttributeValue
+                    {
+                        Name = match.Groups[1].Value,
+                        Value = item.Value.Value<string>()
+                    };
+                }
+            }
+            return existingValue;
+        }
+
+        /// <summary>
+        /// Writes the JSON representation of the object.
+        /// </summary>
+        /// <param name="writer">The <see cref="T:Newtonsoft.Json.JsonWriter" /> to write to.</param>
+        /// <param name="value">The value.</param>
+        /// <param name="serializer">The calling serializer.</param>
+        public override void WriteJson(JsonWriter writer, AttributeFilter value, JsonSerializer serializer)
+        {
+            var dict = new Dictionary<string, string>();
+            if (value.SchemaId != null) dict["schema_id"] = value.SchemaId;
+            if (value.SchemaName != null) dict["schema_name"] = value.SchemaName;
+            if (value.CredentialDefinitionId != null) dict["cred_def_id"] = value.CredentialDefinitionId;
+            if (value.IssuerDid != null) dict["issuer_did"] = value.IssuerDid;
+            if (value.SchemaIssuerDid != null) dict["schema_issuer_did"] = value.SchemaIssuerDid;
+            if (value.SchemaVersion != null) dict["schema_version"] = value.SchemaVersion;
+            if (value.AttributeValue != null) dict[$"attr::{value.AttributeValue.Name}::value"] = value.AttributeValue.Value;
+
+            serializer.Serialize(writer, dict);
+        }
+    }
+}

--- a/src/Hyperledger.Aries/Features/PresentProof/Models/ProofAttributeInfo.cs
+++ b/src/Hyperledger.Aries/Features/PresentProof/Models/ProofAttributeInfo.cs
@@ -1,9 +1,6 @@
 ﻿using System.Collections.Generic;
 using Newtonsoft.Json;
 using System.Linq;
-using System;
-using Newtonsoft.Json.Linq;
-using System.Text.RegularExpressions;
 
 namespace Hyperledger.Aries.Features.PresentProof
 {
@@ -40,68 +37,25 @@ namespace Hyperledger.Aries.Features.PresentProof
         public AttributeValue AttributeValue { get; set; }
     }
 
-    public class AttributeFilterConverter : JsonConverter<AttributeFilter>
-    {
-        /// <summary>
-        /// Reads the JSON representation of the object.
-        /// </summary>
-        /// <param name="reader">The <see cref="T:Newtonsoft.Json.JsonReader" /> to read from.</param>
-        /// <param name="objectType">Type of the object.</param>
-        /// <param name="existingValue">The existing value of object being read. If there is no existing value then <c>null</c> will be used.</param>
-        /// <param name="hasExistingValue">The existing value has a value.</param>
-        /// <param name="serializer">The calling serializer.</param>
-        /// <returns>
-        /// The object value.
-        /// </returns>
-        public override AttributeFilter ReadJson(JsonReader reader, Type objectType, AttributeFilter existingValue, bool hasExistingValue, JsonSerializer serializer)
-        {
-            var items = JObject.Load(reader);
-
-            if (!hasExistingValue) existingValue = new AttributeFilter();
-
-            serializer.Populate(items.CreateReader(), existingValue);
-
-            var regex = new Regex("^attr::([^:]+)::(value)$");
-            foreach (var item in items)
-            {
-                if (regex.IsMatch(item.Key))
-                {
-                    var match = regex.Match(item.Key);
-                    existingValue.AttributeValue = new AttributeValue
-                    {
-                        Name = match.Groups[1].Value,
-                        Value = item.Value.Value<string>()
-                    };
-                }
-            }
-            return existingValue;
-        }
-
-        /// <summary>
-        /// Writes the JSON representation of the object.
-        /// </summary>
-        /// <param name="writer">The <see cref="T:Newtonsoft.Json.JsonWriter" /> to write to.</param>
-        /// <param name="value">The value.</param>
-        /// <param name="serializer">The calling serializer.</param>
-        public override void WriteJson(JsonWriter writer, AttributeFilter value, JsonSerializer serializer)
-        {
-            var dict = new Dictionary<string, string>();
-            if (value.SchemaId != null) dict["schema_id"] = value.SchemaId;
-            if (value.SchemaName != null) dict["schema_name"] = value.SchemaName;
-            if (value.CredentialDefinitionId != null) dict["cred_def_id"] = value.CredentialDefinitionId;
-            if (value.IssuerDid != null) dict["issuer_did"] = value.IssuerDid;
-            if (value.SchemaIssuerDid != null) dict["schema_issuer_did"] = value.SchemaIssuerDid;
-            if (value.SchemaVersion != null) dict["schema_version"] = value.SchemaVersion;
-            if (value.AttributeValue != null) dict[$"attr::{value.AttributeValue.Name}::value"] = value.AttributeValue.Value;
-
-            serializer.Serialize(writer, dict);
-        }
-    }
-
+    /// <summary>
+    /// Attribute Value as restriction
+    /// </summary>
     public class AttributeValue
     {
+        /// <summary>
+        /// The name of the attribute
+        /// </summary>
+        /// <value>
+        /// The name.
+        /// </value>
         public string Name { get; set; }
 
+        /// <summary>
+        /// The expected attribute value
+        /// </summary>
+        /// <value>
+        /// The value.
+        /// </value>
         public string Value { get; set; }
     }
 

--- a/src/Hyperledger.Aries/Features/PresentProof/Models/ProofAttributeInfo.cs
+++ b/src/Hyperledger.Aries/Features/PresentProof/Models/ProofAttributeInfo.cs
@@ -1,6 +1,9 @@
 ﻿using System.Collections.Generic;
 using Newtonsoft.Json;
 using System.Linq;
+using System;
+using Newtonsoft.Json.Linq;
+using System.Text.RegularExpressions;
 
 namespace Hyperledger.Aries.Features.PresentProof
 {
@@ -30,6 +33,76 @@ namespace Hyperledger.Aries.Features.PresentProof
         /// <summary>The credential definition identifier</summary>
         [JsonProperty("cred_def_id", NullValueHandling = NullValueHandling.Ignore)]
         public string CredentialDefinitionId { get; set; }
+
+        /// <summary>
+        /// The attribute name and value to add as restriction.
+        /// </summary>
+        public AttributeValue AttributeValue { get; set; }
+    }
+
+    public class AttributeFilterConverter : JsonConverter<AttributeFilter>
+    {
+        /// <summary>
+        /// Reads the JSON representation of the object.
+        /// </summary>
+        /// <param name="reader">The <see cref="T:Newtonsoft.Json.JsonReader" /> to read from.</param>
+        /// <param name="objectType">Type of the object.</param>
+        /// <param name="existingValue">The existing value of object being read. If there is no existing value then <c>null</c> will be used.</param>
+        /// <param name="hasExistingValue">The existing value has a value.</param>
+        /// <param name="serializer">The calling serializer.</param>
+        /// <returns>
+        /// The object value.
+        /// </returns>
+        public override AttributeFilter ReadJson(JsonReader reader, Type objectType, AttributeFilter existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            var items = JObject.Load(reader);
+
+            if (!hasExistingValue) existingValue = new AttributeFilter();
+
+            serializer.Populate(items.CreateReader(), existingValue);
+
+            var regex = new Regex("^attr::([^:]+)::(value)$");
+            foreach (var item in items)
+            {
+                if (regex.IsMatch(item.Key))
+                {
+                    var match = regex.Match(item.Key);
+                    existingValue.AttributeValue = new AttributeValue
+                    {
+                        Name = match.Groups[1].Value,
+                        Value = item.Value.Value<string>()
+                    };
+                }
+            }
+            return existingValue;
+        }
+
+        /// <summary>
+        /// Writes the JSON representation of the object.
+        /// </summary>
+        /// <param name="writer">The <see cref="T:Newtonsoft.Json.JsonWriter" /> to write to.</param>
+        /// <param name="value">The value.</param>
+        /// <param name="serializer">The calling serializer.</param>
+        public override void WriteJson(JsonWriter writer, AttributeFilter value, JsonSerializer serializer)
+        {
+            var dict = new Dictionary<string, string>();
+            if (value.SchemaId != null) dict["schema_id"] = value.SchemaId;
+            if (value.SchemaName != null) dict["schema_name"] = value.SchemaName;
+            if (value.CredentialDefinitionId != null) dict["cred_def_id"] = value.CredentialDefinitionId;
+            if (value.IssuerDid != null) dict["issuer_did"] = value.IssuerDid;
+            if (value.SchemaIssuerDid != null) dict["schema_issuer_did"] = value.SchemaIssuerDid;
+            if (value.SchemaVersion != null) dict["schema_version"] = value.SchemaVersion;
+            if (value.AttributeValue != null) dict[$"attr::{value.AttributeValue.Name}::value"] = value.AttributeValue.Value;
+
+            serializer.Serialize(writer, dict);
+        }
+    }
+
+    public class AttributeValue
+    {
+        public string Name { get; set; }
+
+        public string Value { get; set; }
     }
 
     /// <summary>

--- a/src/Hyperledger.Aries/Storage/DefaultWalletRecordService.cs
+++ b/src/Hyperledger.Aries/Storage/DefaultWalletRecordService.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Hyperledger.Aries.Agents;
 using Hyperledger.Aries.Extensions;
+using Hyperledger.Aries.Features.PresentProof;
 using Hyperledger.Indy.NonSecretsApi;
 using Hyperledger.Indy.WalletApi;
 using Newtonsoft.Json;
@@ -24,7 +25,8 @@ namespace Hyperledger.Aries.Storage
                 NullValueHandling = NullValueHandling.Ignore,
                 Converters = new List<JsonConverter>
                 {
-                    new AgentEndpointJsonConverter()
+                    new AgentEndpointJsonConverter(),
+                    new AttributeFilterConverter()
                 }
             };
         }

--- a/test/Hyperledger.Aries.Tests/ConverterTests.cs
+++ b/test/Hyperledger.Aries.Tests/ConverterTests.cs
@@ -6,6 +6,7 @@ using Xunit;
 using Hyperledger.Aries.Agents;
 using Hyperledger.Aries.Features.IssueCredential;
 using System.Linq;
+using Hyperledger.Aries.Features.PresentProof;
 
 namespace Hyperledger.Aries.Tests
 {
@@ -83,6 +84,39 @@ namespace Hyperledger.Aries.Tests
 
             var endpoint = json.ToObject<AgentEndpoint>();
             Assert.Equal("1", endpoint.Did);
+        }
+
+        [Fact(DisplayName = "Convert attribute filter to correct JSON")]
+        public void ConvertAttributeValueToJson()
+        {
+            var filter = new AttributeFilter
+            {
+                SchemaId = "1",
+                AttributeValue = new AttributeValue
+                {
+                    Name = "full-name",
+                    Value = "alice"
+                }
+            };
+
+            var json = filter.ToJson();
+
+            Assert.NotNull(json);
+            Assert.Equal("{\"schema_id\":\"1\",\"attr::full-name::value\":\"alice\"}", json);
+        }
+
+        [Fact(DisplayName = "Convert JSON to attribute filter")]
+        public void ConvertJsonToAttributeFilter()
+        {
+            var json = "{\"schema_id\":\"1\",\"attr::full name::value\":\"alice\"}";
+            var filter = json.ToObject<AttributeFilter>();
+
+            Assert.NotNull(filter);
+            Assert.NotNull(filter.AttributeValue);
+            Assert.Equal("full name", filter.AttributeValue.Name);
+            Assert.Equal("alice", filter.AttributeValue.Value);
+            Assert.Equal("1", filter.SchemaId);
+            Assert.Null(filter.CredentialDefinitionId);
         }
     }
 


### PR DESCRIPTION
Signed-off-by: Tomislav Markovski <tomislav@streetcred.id>

Adds support for specifying attribute value in the restrictions object for proof requests.
Libindy allows specifying restrictions based on value as `attr::<name>::value`. This PR adds the ability to specify only the name and value in a strongly typed object.