### PR TITLE
[FIX] connectionless credential offer | fixing the procedure to store a connectionless credential offer

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
  <PropertyGroup>
-   <Version>1.1.11</Version>
+   <Version>1.1.12</Version>
    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Company>Hyperledger</Company>
     <Authors>Hyperledger Aries Dotnet Maintainers</Authors>

--- a/src/Hyperledger.Aries/Features/IssueCredential/DefaultCredentialService.cs
+++ b/src/Hyperledger.Aries/Features/IssueCredential/DefaultCredentialService.cs
@@ -382,7 +382,6 @@ namespace Hyperledger.Aries.Features.IssueCredential
                 revRegDefJson: revocationRegistryDefinitionJson);
 
             credentialRecord.CredentialId = credentialId;
-            credentialRecord.CredentialAttributesValues = null;
 
             await credentialRecord.TriggerAsync(CredentialTrigger.Issue);
             await RecordService.UpdateAsync(agentContext.Wallet, credentialRecord);

--- a/test/Hyperledger.Aries.Tests/Protocols/CredentialTransientTests.cs
+++ b/test/Hyperledger.Aries.Tests/Protocols/CredentialTransientTests.cs
@@ -63,6 +63,7 @@ namespace Hyperledger.Aries.Tests.Protocols
             Assert.NotNull(holderRecord);
             Assert.Equal(expected: CredentialState.Issued, actual: holderRecord.State);
             Assert.Equal(expected: CredentialState.Issued, actual: issuerRecord.State);
+            Assert.NotNull(holderRecord.CredentialAttributesValues);
             Assert.Null(holderRecord.ConnectionId);
         }
     }


### PR DESCRIPTION
#### Short description of what this resolves:
This PR resolves the issue where the Credential Attributes were set explicitly to null when receiving a connectionless credential

#### Changes proposed in this pull request:

- Remove the explicitly null set value
- Update test case that covers the flow

**Fixes**: #
- DefaultCredentialService
- CredentialTransientTest