### PR TITLE
Revocation registry auto scale support

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
  <PropertyGroup>
-   <Version>1.1.12</Version>
+   <Version>1.2.0</Version>
    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Company>Hyperledger</Company>
     <Authors>Hyperledger Aries Dotnet Maintainers</Authors>

--- a/src/Hyperledger.Aries.AspNetCore/ApplicationBuilderExtensions.cs
+++ b/src/Hyperledger.Aries.AspNetCore/ApplicationBuilderExtensions.cs
@@ -1,6 +1,8 @@
 ﻿using Hyperledger.Aries.Agents;
 using Hyperledger.Aries.AspNetCore;
+using Hyperledger.Aries.Configuration;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -21,8 +23,12 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="app">App.</param>
         public static void UseAriesFramework<T>(this IApplicationBuilder app)
         {
+            var options = app.ApplicationServices.GetRequiredService<IOptions<AgentOptions>>().Value;
+
             app.UseMiddleware<T>();
-            app.UseMiddleware<TailsMiddleware>();
+            app.MapWhen(
+                context => context.Request.Path.ToUriComponent().Contains(options.RevocationRegistryUriPath), 
+                app => app.UseMiddleware<TailsMiddleware>());
         }
     }
 }

--- a/src/Hyperledger.Aries.AspNetCore/ApplicationBuilderExtensions.cs
+++ b/src/Hyperledger.Aries.AspNetCore/ApplicationBuilderExtensions.cs
@@ -13,12 +13,16 @@ namespace Microsoft.Extensions.DependencyInjection
         /// Allows default agent configuration
         /// </summary>
         /// <param name="app">App.</param>
-        public static void UseAriesFramework(this IApplicationBuilder app) => app.UseMiddleware<AgentMiddleware>();
+        public static void UseAriesFramework(this IApplicationBuilder app) => UseAriesFramework<AgentMiddleware>(app);
 
         /// <summary>
         /// Allows agent configuration by specifying a custom middleware
         /// </summary>
         /// <param name="app">App.</param>
-        public static void UseAriesFramework<T>(this IApplicationBuilder app) => app.UseMiddleware<T>();
+        public static void UseAriesFramework<T>(this IApplicationBuilder app)
+        {
+            app.UseMiddleware<T>();
+            app.UseMiddleware<TailsMiddleware>();
+        }
     }
 }

--- a/src/Hyperledger.Aries/Common/ErrorCode.cs
+++ b/src/Hyperledger.Aries/Common/ErrorCode.cs
@@ -51,6 +51,9 @@
         /// Encoding values in the supplied proof are invalid
         /// </summary>
         InvalidProofEncoding,
+        /// <summary>
+        /// The revocation registry unavailable
+        /// </summary>
         RevocationRegistryUnavailable
     }
 }

--- a/src/Hyperledger.Aries/Configuration/AgentOptions.cs
+++ b/src/Hyperledger.Aries/Configuration/AgentOptions.cs
@@ -117,12 +117,15 @@ namespace Hyperledger.Aries.Configuration
         } = 2;
 
         /// <summary>
-        /// Gets or sets the revocation registry base URI.
+        /// Gets or sets the revocation registry URI path e.g. "/tails".
+        /// This path will be appended to the EndpointUri value.
+        /// This is used to optimize the ASP.NET Core middleware pipeline.
+        /// Default value is "/tails". The value must start with a slash '/'.
         /// </summary>
         /// <value>
-        /// The revocation registry base URI.
+        /// The revocation registry base URI path.
         /// </value>
-        public string RevocationRegistryBaseUri { get; set; }
+        public string RevocationRegistryUriPath { get; set; } = "/tails";
 
         /// <summary>
         /// Gets or sets the revocation registry directory where

--- a/src/Hyperledger.Aries/Configuration/AgentOptions.cs
+++ b/src/Hyperledger.Aries/Configuration/AgentOptions.cs
@@ -1,4 +1,5 @@
 ﻿using Hyperledger.Aries.Storage;
+using Hyperledger.Aries.Utils;
 
 namespace Hyperledger.Aries.Configuration
 {
@@ -122,5 +123,15 @@ namespace Hyperledger.Aries.Configuration
         /// The revocation registry base URI.
         /// </value>
         public string RevocationRegistryBaseUri { get; set; }
+
+        /// <summary>
+        /// Gets or sets the revocation registry directory where
+        /// revocation tails files will be stored. The default path 
+        /// is ~/.indy_client/tails
+        /// </summary>
+        /// <value>
+        /// The revocation registry directory.
+        /// </value>
+        public string RevocationRegistryDirectory { get; set; } = EnvironmentUtils.GetTailsPath();
     }
 }

--- a/src/Hyperledger.Aries/Configuration/AgentOptions.cs
+++ b/src/Hyperledger.Aries/Configuration/AgentOptions.cs
@@ -114,5 +114,13 @@ namespace Hyperledger.Aries.Configuration
             get;
             set;
         } = 2;
+
+        /// <summary>
+        /// Gets or sets the revocation registry base URI.
+        /// </summary>
+        /// <value>
+        /// The revocation registry base URI.
+        /// </value>
+        public string RevocationRegistryBaseUri { get; set; }
     }
 }

--- a/src/Hyperledger.Aries/Features/IssueCredential/Abstractions/ISchemaService.cs
+++ b/src/Hyperledger.Aries/Features/IssueCredential/Abstractions/ISchemaService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Hyperledger.Aries.Agents;
 using Hyperledger.Aries.Models.Records;
+using Hyperledger.Indy.AnonCredsApi;
 using Hyperledger.Indy.PoolApi;
 using Hyperledger.Indy.WalletApi;
 
@@ -49,8 +50,25 @@ namespace Hyperledger.Aries.Features.IssueCredential
         /// his parameter is only used if <paramref name="supportsRevocation" /> is <c>true</c>.</param>
         /// <returns>The credential definition identifier of the stored definition record.
         /// This identifier can be used for ledger definition lookup.</returns>
-        Task<string> CreateCredentialDefinitionAsync(IAgentContext context, string schemaId, string issuerDid,
-            string tag, bool supportsRevocation, int maxCredentialCount, Uri tailsBaseUri);
+        [Obsolete("This method is obsolete. Please use 'CreateCredentialDefinitionAsync(IAgentContext, CredentialDefinitionConfiguration)'")]
+        Task<string> CreateCredentialDefinitionAsync(IAgentContext context, string schemaId, string issuerDid, string tag, bool supportsRevocation, int maxCredentialCount, Uri tailsBaseUri);
+
+        /// <summary>
+        /// Creates new credential definition with the given configuration
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="configuration">The configuration.</param>
+        /// <returns></returns>
+        Task<string> CreateCredentialDefinitionAsync(IAgentContext context, CredentialDefinitionConfiguration configuration);
+
+        /// <summary>
+        /// Creates new revocation registry record and definition for the given credential definition.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="tag">The tag.</param>
+        /// <param name="definitionRecord">The definition record.</param>
+        /// <returns></returns>
+        Task<(IssuerCreateAndStoreRevocRegResult, RevocationRegistryRecord)> CreateRevocationRegistryAsync(IAgentContext context, string tag, DefinitionRecord definitionRecord);
 
         /// <summary>Creates the credential definition and registers it on the ledger.</summary>
         /// <param name="context">The agent context</param>
@@ -59,8 +77,8 @@ namespace Hyperledger.Aries.Features.IssueCredential
         /// <param name="supportsRevocation">if set to <c>true</c> [supports revocation].</param>
         /// <param name="maxCredentialCount">The maximum credential count.</param>
         /// <returns></returns>
-        Task<string> CreateCredentialDefinitionAsync(IAgentContext context, string schemaId,
-            string tag, bool supportsRevocation, int maxCredentialCount);
+        [Obsolete("This method is obsolete. Please use 'CreateCredentialDefinitionAsync(IAgentContext, CredentialDefinitionConfiguration)'")]
+        Task<string> CreateCredentialDefinitionAsync(IAgentContext context, string schemaId, string tag, bool supportsRevocation, int maxCredentialCount);
 
         /// <summary>
         /// Gets the schemas asynchronous.

--- a/src/Hyperledger.Aries/Features/IssueCredential/DefaultCredentialService.cs
+++ b/src/Hyperledger.Aries/Features/IssueCredential/DefaultCredentialService.cs
@@ -370,9 +370,9 @@ namespace Hyperledger.Aries.Features.IssueCredential
             if (!string.IsNullOrEmpty(revRegId))
             {
                 // If credential supports revocation, lookup registry definition
-                var revocationRegistry =
-                    await LedgerService.LookupRevocationRegistryDefinitionAsync(await agentContext.Pool, revRegId);
+                var revocationRegistry = await LedgerService.LookupRevocationRegistryDefinitionAsync(await agentContext.Pool, revRegId);
                 revocationRegistryDefinitionJson = revocationRegistry.ObjectJson;
+                credentialRecord.RevocationRegistryId = revRegId;
             }
 
             var credentialId = await AnonCreds.ProverStoreCredentialAsync(
@@ -659,10 +659,10 @@ namespace Hyperledger.Aries.Features.IssueCredential
             }
 
             var (_, nextRevocationRecord) = await SchemaService.CreateRevocationRegistryAsync(agentContext, registryTag, definitionRecord);
-            definitionRecord.CurrentRevocationRegistryId = revocationRecord.Id;
+            definitionRecord.CurrentRevocationRegistryId = nextRevocationRecord.Id;
             await RecordService.UpdateAsync(agentContext.Wallet, definitionRecord);
 
-            tailsReader = await TailsService.OpenTailsAsync(revocationRecord.TailsFile);
+            tailsReader = await TailsService.OpenTailsAsync(nextRevocationRecord.TailsFile);
             return (await AnonCreds.IssuerCreateCredentialAsync(
                                 agentContext.Wallet,
                                 credentialRecord.OfferJson,

--- a/src/Hyperledger.Aries/Features/IssueCredential/DefaultSchemaService.cs
+++ b/src/Hyperledger.Aries/Features/IssueCredential/DefaultSchemaService.cs
@@ -234,12 +234,7 @@ namespace Hyperledger.Aries.Features.IssueCredential
                 //if (paymentInfo != null) await RecordService.UpdateAsync(context.Wallet, paymentInfo.PaymentAddress);
 
                 //paymentInfo = await paymentService.GetTransactionCostAsync(context, TransactionTypes.REVOC_REG_ENTRY);
-                await LedgerService.SendRevocationRegistryEntryAsync(context: context,
-                                                                     issuerDid: configuration.IssuerDid,
-                                                                     revocationRegistryDefinitionId: revocationRegistry.RevRegId,
-                                                                     revocationDefinitionType: "CL_ACCUM",
-                                                                     value: revocationRegistry.RevRegEntryJson,
-                                                                     paymentInfo: null);
+
                 //if (paymentInfo != null) await RecordService.UpdateAsync(context.Wallet, paymentInfo.PaymentAddress);
             }
 
@@ -283,12 +278,21 @@ namespace Hyperledger.Aries.Features.IssueCredential
             revocationRecord.TailsFile = tailsfile;
 
             //paymentInfo = await paymentService.GetTransactionCostAsync(context, TransactionTypes.REVOC_REG_DEF);
-            await LedgerService.RegisterRevocationRegistryDefinitionAsync(context: context,
-                                                                          submitterDid: definitionRecord.IssuerDid,
-                                                                          data: revocationDefinition.ToString(),
-                                                                          paymentInfo: null);
+            await LedgerService.RegisterRevocationRegistryDefinitionAsync(
+                context: context,
+                submitterDid: definitionRecord.IssuerDid,
+                data: revocationDefinition.ToString(),
+                paymentInfo: null);
 
             await RecordService.AddAsync(context.Wallet, revocationRecord);
+
+            await LedgerService.SendRevocationRegistryEntryAsync(
+                context: context,
+                issuerDid: definitionRecord.IssuerDid,
+                revocationRegistryDefinitionId: revocationRegistry.RevRegId,
+                revocationDefinitionType: "CL_ACCUM",
+                value: revocationRegistry.RevRegEntryJson,
+                paymentInfo: null);
 
             return (revocationRegistry, revocationRecord);
         }

--- a/src/Hyperledger.Aries/Features/IssueCredential/Models/CredentialDefinitionConfiguration.cs
+++ b/src/Hyperledger.Aries/Features/IssueCredential/Models/CredentialDefinitionConfiguration.cs
@@ -1,0 +1,75 @@
+﻿using Hyperledger.Aries.Configuration;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Hyperledger.Aries.Features.IssueCredential
+{
+    /// <summary>
+    /// Credential definition configuration
+    /// </summary>
+    public class CredentialDefinitionConfiguration
+    {
+        /// <summary>
+        /// Gets or sets the schema identifier.
+        /// </summary>
+        /// <value>
+        /// The schema identifier.
+        /// </value>
+        public string SchemaId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the issuer DID. If this field is not specified, it will
+        /// be read from the <see cref="ProvisioningRecord" />.
+        /// </summary>
+        /// <value>
+        /// The issuer did.
+        /// </value>
+        public string IssuerDid { get; set; }
+
+        /// <summary>
+        /// Gets or sets the tag of the credential definition.
+        /// Tags allow differentiating credential definitions of the same schema and issuer.
+        /// </summary>
+        /// <value>
+        /// The tag.
+        /// </value>
+        public string Tag { get; set; } = "default";
+
+        /// <summary>
+        /// Gets or sets the enable revocation.
+        /// </summary>
+        /// <value>
+        /// The enable revocation.
+        /// </value>
+        public bool EnableRevocation { get; set; }
+
+        /// <summary>
+        /// Gets or sets the size of the revocation registry.
+        /// </summary>
+        /// <value>
+        /// The size of the revocation registry.
+        /// </value>
+        public int RevocationRegistrySize { get; set; } = 1024;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the revocation registry scales automatically.
+        /// This means that a new revocation registry will be created as soon as the existing one
+        /// reaches maximum credential issuance.
+        /// This feature improves the size of the revocation registry tails file.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if [revocation registry automatic scale]; otherwise, <c>false</c>.
+        /// </value>
+        public bool RevocationRegistryAutoScale { get; set; } = true;
+
+        /// <summary>
+        /// Gets the revocation registry base URI. If this is not specified, the value
+        /// will be taken from <see cref="AgentOptions" />
+        /// </summary>
+        /// <value>
+        /// The revocation registry base URI.
+        /// </value>
+        public string RevocationRegistryBaseUri { get; set; }
+    }
+}

--- a/src/Hyperledger.Aries/Features/IssueCredential/Records/CredentialRecord.cs
+++ b/src/Hyperledger.Aries/Features/IssueCredential/Records/CredentialRecord.cs
@@ -153,6 +153,14 @@ namespace Hyperledger.Aries.Features.IssueCredential
         }
 
         /// <summary>
+        /// Gets or sets the revocation registry identifier.
+        /// </summary>
+        /// <value>
+        /// The revocation registry identifier.
+        /// </value>
+        public string RevocationRegistryId { get; set; }
+
+        /// <summary>
         /// Triggers the async.
         /// </summary>
         /// <returns>The async.</returns>

--- a/src/Hyperledger.Aries/Features/IssueCredential/Records/DefinitionRecord.cs
+++ b/src/Hyperledger.Aries/Features/IssueCredential/Records/DefinitionRecord.cs
@@ -52,7 +52,39 @@ namespace Hyperledger.Aries.Models.Records
         /// <summary>Gets or sets the maximum credential count.</summary>
         /// <value>The maximum credential count.</value>
         public int MaxCredentialCount { get; set; }
-        
+
+        /// <summary>
+        /// Gets a value indicating whether revocation automatic scales.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if [revocation automatic scale]; otherwise, <c>false</c>.
+        /// </value>
+        public bool RevocationAutoScale { get; set; }
+
+        /// <summary>
+        /// Gets or sets the current revocation registry identifier.
+        /// </summary>
+        /// <value>
+        /// The current revocation registry identifier.
+        /// </value>
+        public string CurrentRevocationRegistryId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the issuer DID.
+        /// </summary>
+        /// <value>
+        /// The issuer did.
+        /// </value>
+        public string IssuerDid { get; set; }
+
+        /// <summary>
+        /// Gets or sets the revocation registry base URI.
+        /// </summary>
+        /// <value>
+        /// The revocation registry base URI.
+        /// </value>
+        public string RevocationRegistryBaseUri { get; set; }
+
         /// <inheritdoc />
         public override string ToString() =>
             $"{GetType().Name}: " +

--- a/src/Hyperledger.Aries/Features/IssueCredential/Records/DefinitionRecord.cs
+++ b/src/Hyperledger.Aries/Features/IssueCredential/Records/DefinitionRecord.cs
@@ -76,22 +76,5 @@ namespace Hyperledger.Aries.Models.Records
         /// The issuer did.
         /// </value>
         public string IssuerDid { get; set; }
-
-        /// <summary>
-        /// Gets or sets the revocation registry base URI.
-        /// </summary>
-        /// <value>
-        /// The revocation registry base URI.
-        /// </value>
-        public string RevocationRegistryBaseUri { get; set; }
-
-        /// <inheritdoc />
-        public override string ToString() =>
-            $"{GetType().Name}: " +
-            $"SchemaId={SchemaId}, " +
-            $"SupportsRevocation={SupportsRevocation}, " +
-            $"RequireApproval={RequireApproval}, " +
-            $"MaxCredentialCount={MaxCredentialCount}, " +
-            base.ToString(); 
     }
 }

--- a/src/Hyperledger.Aries/Features/IssueCredential/Records/RevocationRegistryRecord.cs
+++ b/src/Hyperledger.Aries/Features/IssueCredential/Records/RevocationRegistryRecord.cs
@@ -33,11 +33,12 @@ namespace Hyperledger.Aries.Models.Records
         /// <returns>The type name.</returns>
         public override string TypeName => "AF.RevocationRegistryRecord";
 
-        /// <inheritdoc />
-        public override string ToString() =>
-            $"{GetType().Name}: " +
-            $"CredentialDefinitionId={CredentialDefinitionId}, " +
-            $"TailsFile={TailsFile}, " +
-            base.ToString();
+        /// <summary>
+        /// Gets or sets the public URI tails location.
+        /// </summary>
+        /// <value>
+        /// The tails location.
+        /// </value>
+        public string TailsLocation { get; set; }
     }
 }

--- a/src/Hyperledger.Aries/Hyperledger.Aries.csproj
+++ b/src/Hyperledger.Aries/Hyperledger.Aries.csproj
@@ -13,6 +13,7 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Flurl" Version="2.8.2" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />

--- a/test/Hyperledger.Aries.Tests/Protocols/CredentialTests.cs
+++ b/test/Hyperledger.Aries.Tests/Protocols/CredentialTests.cs
@@ -23,6 +23,7 @@ using Hyperledger.Aries.Features.IssueCredential;
 using Hyperledger.Aries.Ledger;
 using Hyperledger.Aries.Payments;
 using Hyperledger.Aries.Storage;
+using Microsoft.Extensions.Options;
 
 namespace Hyperledger.Aries.Tests.Protocols
 {
@@ -64,7 +65,7 @@ namespace Hyperledger.Aries.Tests.Protocols
                 .Returns(new HttpClient());
 
             var tailsService = new DefaultTailsService(ledgerService, clientFactory.Object);
-            _schemaService = new DefaultSchemaService(provisioning, recordService, ledgerService, paymentService, tailsService);
+            _schemaService = new DefaultSchemaService(provisioning, recordService, ledgerService, paymentService, tailsService, Options.Create(new Configuration.AgentOptions()));
 
             _connectionService = new DefaultConnectionService(
                 _eventAggregator,

--- a/test/Hyperledger.Aries.Tests/Protocols/CredentialTests.cs
+++ b/test/Hyperledger.Aries.Tests/Protocols/CredentialTests.cs
@@ -64,7 +64,7 @@ namespace Hyperledger.Aries.Tests.Protocols
             clientFactory.Setup(x => x.CreateClient(It.IsAny<string>()))
                 .Returns(new HttpClient());
 
-            var tailsService = new DefaultTailsService(ledgerService, clientFactory.Object);
+            var tailsService = new DefaultTailsService(ledgerService, Options.Create(new Configuration.AgentOptions()), clientFactory.Object);
             _schemaService = new DefaultSchemaService(provisioning, recordService, ledgerService, paymentService, tailsService, Options.Create(new Configuration.AgentOptions()));
 
             _connectionService = new DefaultConnectionService(

--- a/test/Hyperledger.Aries.Tests/Protocols/CredentialTransientTests.cs
+++ b/test/Hyperledger.Aries.Tests/Protocols/CredentialTransientTests.cs
@@ -85,6 +85,10 @@ namespace Hyperledger.Aries.Tests.Protocols
                 version: "1.0",
                 attributeNames: new[] { "test-attr" });
 
+            string revocationRegistryId1 = null;
+            string revocationRegistryId2 = null;
+            string revocationRegistryId3 = null;
+
             var credentialDefinitionId = await issuerSchemaService.CreateCredentialDefinitionAsync(
                 context: agents.Agent1.Context,
                 new CredentialDefinitionConfiguration
@@ -120,6 +124,8 @@ namespace Hyperledger.Aries.Tests.Protocols
                 Assert.Null(holderRecord.ConnectionId);
                 Assert.Equal(definitionRecord.CurrentRevocationRegistryId, issuerRecord.RevocationRegistryId);
                 Assert.Equal(definitionRecord.CurrentRevocationRegistryId, holderRecord.RevocationRegistryId);
+
+                revocationRegistryId1 = definitionRecord.CurrentRevocationRegistryId;
             }
 
             // Second credential, will auto scale registry
@@ -147,6 +153,8 @@ namespace Hyperledger.Aries.Tests.Protocols
                 Assert.Null(holderRecord.ConnectionId);
                 Assert.Equal(definitionRecord.CurrentRevocationRegistryId, issuerRecord.RevocationRegistryId);
                 Assert.Equal(definitionRecord.CurrentRevocationRegistryId, holderRecord.RevocationRegistryId);
+
+                revocationRegistryId2 = definitionRecord.CurrentRevocationRegistryId;
             }
 
             // Third credential, will auto scale registry
@@ -174,7 +182,13 @@ namespace Hyperledger.Aries.Tests.Protocols
                 Assert.Null(holderRecord.ConnectionId);
                 Assert.Equal(definitionRecord.CurrentRevocationRegistryId, issuerRecord.RevocationRegistryId);
                 Assert.Equal(definitionRecord.CurrentRevocationRegistryId, holderRecord.RevocationRegistryId);
+
+                revocationRegistryId3 = definitionRecord.CurrentRevocationRegistryId;
             }
+
+            Assert.NotEqual(revocationRegistryId1, revocationRegistryId2);
+            Assert.NotEqual(revocationRegistryId2, revocationRegistryId3);
+            Assert.NotEqual(revocationRegistryId1, revocationRegistryId3);
         }
     }
 }

--- a/test/Hyperledger.Aries.Tests/Protocols/ProofTests.cs
+++ b/test/Hyperledger.Aries.Tests/Protocols/ProofTests.cs
@@ -23,6 +23,7 @@ using Hyperledger.Aries.Features.PresentProof;
 using Hyperledger.Aries.Ledger;
 using Hyperledger.Aries.Payments;
 using Hyperledger.Aries.Storage;
+using Microsoft.Extensions.Options;
 
 namespace Hyperledger.Aries.Tests.Protocols
 {
@@ -68,7 +69,7 @@ namespace Hyperledger.Aries.Tests.Protocols
                 .Returns(new HttpClient());
 
             var tailsService = new DefaultTailsService(ledgerService, clientFactory.Object);
-            _schemaService = new DefaultSchemaService(provisioning, recordService, ledgerService, paymentService, tailsService);
+            _schemaService = new DefaultSchemaService(provisioning, recordService, ledgerService, paymentService, tailsService, Options.Create(new Configuration.AgentOptions()));
 
             _connectionService = new DefaultConnectionService(
                 _eventAggregator,

--- a/test/Hyperledger.Aries.Tests/Protocols/ProofTests.cs
+++ b/test/Hyperledger.Aries.Tests/Protocols/ProofTests.cs
@@ -68,7 +68,7 @@ namespace Hyperledger.Aries.Tests.Protocols
             clientFactory.Setup(x => x.CreateClient(It.IsAny<string>()))
                 .Returns(new HttpClient());
 
-            var tailsService = new DefaultTailsService(ledgerService, clientFactory.Object);
+            var tailsService = new DefaultTailsService(ledgerService, Options.Create(new Configuration.AgentOptions()), clientFactory.Object);
             _schemaService = new DefaultSchemaService(provisioning, recordService, ledgerService, paymentService, tailsService, Options.Create(new Configuration.AgentOptions()));
 
             _connectionService = new DefaultConnectionService(


### PR DESCRIPTION
This PR adds support for automatic revocation registry handling when we want to scale the revocation registry beyond what is initially allowed.
Changes are backward compatible. To turn on support for revocation, simply specify that revocation is enabled//supported when creating new credential definition.
Other changes include:

- Control where tails files are stored. Use the `AgentOptions` property `RevocationRegistryDirectory` to set this. Default is `~/.indy_client/tails`.
- Added new `CreateCredentialDefinition` method in `SchemaService`. This class adds support for controlling the behavior of revocation registry via `CredentialDefinitionConfiguration`
  - Specify `EnableRevocation` to turn on revocation for the cred def
  - Specify revocation registry size using `RevocationRegistrySize`. Default is 1024. Using a smaller size allows for easier download on mobile devices.
  - Specify automatic scaling of revocation registry by enabling `RevocationRegistryAutoScale`. Default value is `true`. This option will seamlessly create new revocation registry with different tag when the old one is full.
  - Added tails middleware as part of the ASP.NET Core pipeline. This middleware will serve tails files on a public endpoint
- Existing method for creating credential definition have been marked as `Obsolete`. Their behavior is unchanged, but they may be removed at some point in the future when breaking changes can be considered.
- `CredentialRecord`s now track the revocation registry using `RevocationRegistryId`