### PR TITLE
Consoldate the use of AgentContext over Pool

### DIFF
--- a/src/Hyperledger.Aries/Features/IssueCredential/Abstractions/ISchemaService.cs
+++ b/src/Hyperledger.Aries/Features/IssueCredential/Abstractions/ISchemaService.cs
@@ -105,33 +105,41 @@ namespace Hyperledger.Aries.Features.IssueCredential
         /// <summary>
         /// Looks up the credential definition on the ledger.
         /// </summary>
-        /// <param name="pool">The pool.</param>
+        /// <param name="agentContext">The agent context.</param>
         /// <param name="definitionId">The identifier of the definition to resolve.</param>
-        /// <returns>A json string of the credential definition</returns>
-        Task<string> LookupCredentialDefinitionAsync(Pool pool, string definitionId);
+        /// <returns>
+        /// A json string of the credential definition
+        /// </returns>
+        Task<string> LookupCredentialDefinitionAsync(IAgentContext agentContext, string definitionId);
 
         /// <summary>
         /// Looks up the schema definition on the ledger given a credential definition identifier.
         /// </summary>
-        /// <param name="pool">The pool.</param>
+        /// <param name="agentContext">The agent context.</param>
         /// <param name="credentialDefinitionId">The credential definition id.</param>
-        /// <returns>A json string of the schema</returns>
-        Task<string> LookupSchemaFromCredentialDefinitionAsync(Pool pool, string credentialDefinitionId);
+        /// <returns>
+        /// A json string of the schema
+        /// </returns>
+        Task<string> LookupSchemaFromCredentialDefinitionAsync(IAgentContext agentContext, string credentialDefinitionId);
 
         /// <summary>
         /// Looks up the schema definition on the ledger.
         /// </summary>
-        /// <param name="pool">The pool.</param>
+        /// <param name="agentContext">The agent context.</param>
         /// <param name="sequenceId">The sequence identifier of the schema to resolve.</param>
-        /// <returns>A json string of the schema</returns>
-        Task<string> LookupSchemaAsync(Pool pool, int sequenceId);
+        /// <returns>
+        /// A json string of the schema
+        /// </returns>
+        Task<string> LookupSchemaAsync(IAgentContext agentContext, int sequenceId);
 
         /// <summary>
         /// Looks up the schema definition on the ledger.
         /// </summary>
-        /// <param name="pool">The pool.</param>
+        /// <param name="agentContext">The agent context.</param>
         /// <param name="schemaId">The identifier of the schema definition to resolve.</param>
-        /// <returns>A json string of the schema</returns>
-        Task<string> LookupSchemaAsync(Pool pool, string schemaId);
+        /// <returns>
+        /// A json string of the schema
+        /// </returns>
+        Task<string> LookupSchemaAsync(IAgentContext agentContext, string schemaId);
     }
 }

--- a/src/Hyperledger.Aries/Features/IssueCredential/Abstractions/ITailsService.cs
+++ b/src/Hyperledger.Aries/Features/IssueCredential/Abstractions/ITailsService.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using Hyperledger.Aries.Agents;
 using Hyperledger.Indy.BlobStorageApi;
 using Hyperledger.Indy.PoolApi;
 
@@ -25,11 +26,11 @@ namespace Hyperledger.Aries.Features.IssueCredential
         /// <summary>
         /// Check if the tails filename exists locally and download latest version if it doesn't.
         /// </summary>
-        /// <param name="pool">Pool.</param>
+        /// <param name="agentContext">The agent context.</param>
         /// <param name="revocationRegistryId">Revocation registry identifier.</param>
         /// <returns>
         /// The name of the tails file
         /// </returns>
-        Task<string> EnsureTailsExistsAsync(Pool pool, string revocationRegistryId);
+        Task<string> EnsureTailsExistsAsync(IAgentContext agentContext, string revocationRegistryId);
     }
 }

--- a/src/Hyperledger.Aries/Features/IssueCredential/DefaultCredentialService.cs
+++ b/src/Hyperledger.Aries/Features/IssueCredential/DefaultCredentialService.cs
@@ -307,7 +307,7 @@ namespace Hyperledger.Aries.Features.IssueCredential
                 proverDid = newDid.Did;
             }
 
-            var definition = await LedgerService.LookupDefinitionAsync(await agentContext.Pool, credential.CredentialDefinitionId);
+            var definition = await LedgerService.LookupDefinitionAsync(agentContext, credential.CredentialDefinitionId);
             var provisioning = await ProvisioningService.GetProvisioningAsync(agentContext.Wallet);
 
             var request = await AnonCreds.ProverCreateCredentialReqAsync(
@@ -364,13 +364,13 @@ namespace Hyperledger.Aries.Features.IssueCredential
                 throw new AriesFrameworkException(ErrorCode.RecordInInvalidState,
                     $"Credential state was invalid. Expected '{CredentialState.Requested}', found '{credentialRecord.State}'");
 
-            var credentialDefinition = await LedgerService.LookupDefinitionAsync(await agentContext.Pool, definitionId);
+            var credentialDefinition = await LedgerService.LookupDefinitionAsync(agentContext, definitionId);
 
             string revocationRegistryDefinitionJson = null;
             if (!string.IsNullOrEmpty(revRegId))
             {
                 // If credential supports revocation, lookup registry definition
-                var revocationRegistry = await LedgerService.LookupRevocationRegistryDefinitionAsync(await agentContext.Pool, revRegId);
+                var revocationRegistry = await LedgerService.LookupRevocationRegistryDefinitionAsync(agentContext, revRegId);
                 revocationRegistryDefinitionJson = revocationRegistry.ObjectJson;
                 credentialRecord.RevocationRegistryId = revRegId;
             }

--- a/src/Hyperledger.Aries/Features/IssueCredential/DefaultSchemaService.cs
+++ b/src/Hyperledger.Aries/Features/IssueCredential/DefaultSchemaService.cs
@@ -106,10 +106,10 @@ namespace Hyperledger.Aries.Features.IssueCredential
         }
 
         /// <inheritdoc />
-        public async Task<string> LookupSchemaFromCredentialDefinitionAsync(Pool pool,
+        public async Task<string> LookupSchemaFromCredentialDefinitionAsync(IAgentContext agentContext,
             string credentialDefinitionId)
         {
-            var credDef = await LookupCredentialDefinitionAsync(pool, credentialDefinitionId);
+            var credDef = await LookupCredentialDefinitionAsync(agentContext, credentialDefinitionId);
 
             if (string.IsNullOrEmpty(credDef))
                 return null;
@@ -117,7 +117,7 @@ namespace Hyperledger.Aries.Features.IssueCredential
             try
             {
                 var schemaSequenceId = Convert.ToInt32(JObject.Parse(credDef)["schemaId"].ToString());
-                return await LookupSchemaAsync(pool, schemaSequenceId);
+                return await LookupSchemaAsync(agentContext, schemaSequenceId);
             }
             catch (Exception) { }
 
@@ -126,9 +126,9 @@ namespace Hyperledger.Aries.Features.IssueCredential
 
         /// TODO this should return a schema object
         /// <inheritdoc />
-        public virtual async Task<string> LookupSchemaAsync(Pool pool, int sequenceId)
+        public virtual async Task<string> LookupSchemaAsync(IAgentContext agentContext, int sequenceId)
         {
-            var result = await LedgerService.LookupTransactionAsync(pool, null, sequenceId);
+            var result = await LedgerService.LookupTransactionAsync(agentContext, null, sequenceId);
 
             if (!string.IsNullOrEmpty(result))
             {
@@ -155,9 +155,9 @@ namespace Hyperledger.Aries.Features.IssueCredential
 
         /// TODO this should return a schema object
         /// <inheritdoc />
-        public virtual async Task<string> LookupSchemaAsync(Pool pool, string schemaId)
+        public virtual async Task<string> LookupSchemaAsync(IAgentContext agentContext, string schemaId)
         {
-            var result = await LedgerService.LookupSchemaAsync(pool, schemaId);
+            var result = await LedgerService.LookupSchemaAsync(agentContext, schemaId);
             return result?.ObjectJson;
         }
 
@@ -191,7 +191,7 @@ namespace Hyperledger.Aries.Features.IssueCredential
                 configuration.RevocationRegistryBaseUri == null &&
                 AgentOptions.RevocationRegistryUriPath == null) throw new AriesFrameworkException(ErrorCode.InvalidParameterFormat, "RevocationRegistryBaseUri must be specified either in the configuration or the AgentOptions");
 
-            var schema = await LedgerService.LookupSchemaAsync(await context.Pool, configuration.SchemaId);
+            var schema = await LedgerService.LookupSchemaAsync(context, configuration.SchemaId);
 
             var provisioning = await ProvisioningService.GetProvisioningAsync(context.Wallet);
             configuration.IssuerDid ??= provisioning.IssuerDid;
@@ -319,9 +319,9 @@ namespace Hyperledger.Aries.Features.IssueCredential
 
         /// TODO this should return a definition object
         /// <inheritdoc />
-        public virtual async Task<string> LookupCredentialDefinitionAsync(Pool pool, string definitionId)
+        public virtual async Task<string> LookupCredentialDefinitionAsync(IAgentContext agentContext, string definitionId)
         {
-            var result = await LedgerService.LookupDefinitionAsync(pool, definitionId);
+            var result = await LedgerService.LookupDefinitionAsync(agentContext, definitionId);
             return result?.ObjectJson;
         }
 

--- a/src/Hyperledger.Aries/Features/IssueCredential/DefaultTailsService.cs
+++ b/src/Hyperledger.Aries/Features/IssueCredential/DefaultTailsService.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Hyperledger.Aries.Agents;
 using Hyperledger.Aries.Configuration;
 using Hyperledger.Aries.Contracts;
 using Hyperledger.Aries.Extensions;
@@ -86,9 +87,9 @@ namespace Hyperledger.Aries.Features.IssueCredential
         }
 
         /// <inheritdoc />
-        public virtual async Task<string> EnsureTailsExistsAsync(Pool pool, string revocationRegistryId)
+        public virtual async Task<string> EnsureTailsExistsAsync(IAgentContext agentContext, string revocationRegistryId)
         {
-            var revocationRegistry = await LedgerService.LookupRevocationRegistryDefinitionAsync(pool, revocationRegistryId);
+            var revocationRegistry = await LedgerService.LookupRevocationRegistryDefinitionAsync(agentContext, revocationRegistryId);
             var tailsUri = JObject.Parse(revocationRegistry.ObjectJson)["value"]["tailsLocation"].ToObject<string>();
             var tailsFileName = JObject.Parse(revocationRegistry.ObjectJson)["value"]["tailsHash"].ToObject<string>();
 

--- a/src/Hyperledger.Aries/Ledger/Abstractions/ILedgerService.cs
+++ b/src/Hyperledger.Aries/Ledger/Abstractions/ILedgerService.cs
@@ -16,18 +16,20 @@ namespace Hyperledger.Aries.Contracts
         /// <summary>
         /// Gets a list of all authorization rules for the given pool
         /// </summary>
-        /// <param name="pool"></param>
+        /// <param name="agentContext">The agent context.</param>
         /// <returns></returns>
-        Task<IList<AuthorizationRule>> LookupAuthorizationRulesAsync(Pool pool);
+        Task<IList<AuthorizationRule>> LookupAuthorizationRulesAsync(IAgentContext agentContext);
 
         /// <summary>
         /// Looks up an attribute value on the ledger.
         /// </summary>
-        /// <returns>The attribute value or <c>null</c> if none were found.</returns>
-        /// <param name="pool">Pool.</param>
-        /// <param name="targetDid">The target DID for the <paramref name="attributeName"/> lookup</param>
+        /// <param name="agentContext">The agent context.</param>
+        /// <param name="targetDid">The target DID for the <paramref name="attributeName" /> lookup</param>
         /// <param name="attributeName">Attribute name.</param>
-        Task<string> LookupAttributeAsync(Pool pool, string targetDid, string attributeName);
+        /// <returns>
+        /// The attribute value or <c>null</c> if none were found.
+        /// </returns>
+        Task<string> LookupAttributeAsync(IAgentContext agentContext, string targetDid, string attributeName);
 
         /// <summary>
         /// Register an attribute for the specified <paramref name="targetDid"/> to the ledger.
@@ -45,69 +47,73 @@ namespace Hyperledger.Aries.Contracts
         /// <summary>
         /// Lookup the schema async.
         /// </summary>
-        /// <param name="pool">The pool.</param>
+        /// <param name="agentContext">The agent context.</param>
         /// <param name="schemaId">Schema identifier.</param>
         /// <returns>
         /// The schema async.
         /// </returns>
-        Task<ParseResponseResult> LookupSchemaAsync(Pool pool, string schemaId);
+        Task<ParseResponseResult> LookupSchemaAsync(IAgentContext agentContext, string schemaId);
 
         /// <summary>
         /// Lookup NYM record on the ledger
         /// </summary>
-        /// <param name="pool"></param>
-        /// <param name="did"></param>
+        /// <param name="agentContext">The agent context.</param>
+        /// <param name="did">The did.</param>
         /// <returns></returns>
-        Task<string> LookupNymAsync(Pool pool, string did);
+        Task<string> LookupNymAsync(IAgentContext agentContext, string did);
 
         /// <summary>
         /// Lookup the ledger transaction async.
         /// </summary>
-        /// <param name="pool">The pool.</param>
+        /// <param name="agentContext">The agent context.</param>
         /// <param name="ledgerType">The ledger type.</param>
         /// <param name="sequenceId">The sequence identifier.</param>
         /// <returns>
         /// The transaction async.
         /// </returns>
-        Task<string> LookupTransactionAsync(Pool pool, string ledgerType, int sequenceId);
+        Task<string> LookupTransactionAsync(IAgentContext agentContext, string ledgerType, int sequenceId);
 
         /// <summary>
         /// Lookups the definition async.
         /// </summary>
-        /// <param name="pool">The pool.</param>
+        /// <param name="agentContext">The agent context.</param>
         /// <param name="definitionId">Definition identifier.</param>
         /// <returns>
         /// The definition async.
         /// </returns>
-        Task<ParseResponseResult> LookupDefinitionAsync(Pool pool, string definitionId);
+        Task<ParseResponseResult> LookupDefinitionAsync(IAgentContext agentContext, string definitionId);
 
         /// <summary>
         /// Lookups the revocation registry definition.
         /// </summary>
-        /// <param name="pool">The pool.</param>
+        /// <param name="agentContext">The agent context.</param>
         /// <param name="registryId">The registry identifier.</param>
         /// <returns></returns>
-        Task<ParseResponseResult> LookupRevocationRegistryDefinitionAsync(Pool pool, string registryId);
+        Task<ParseResponseResult> LookupRevocationRegistryDefinitionAsync(IAgentContext agentContext, string registryId);
 
         /// <summary>
         /// Lookup the revocation registry delta for the given registry in the range specified.
         /// </summary>
-        /// <returns>The revocation registry delta.</returns>
-        /// <param name="pool">Pool.</param>
+        /// <param name="agentContext">The agent context.</param>
         /// <param name="revocationRegistryId">Revocation registry identifier.</param>
         /// <param name="from">From.</param>
         /// <param name="to">To.</param>
-        Task<ParseRegistryResponseResult> LookupRevocationRegistryDeltaAsync(Pool pool, string revocationRegistryId,
+        /// <returns>
+        /// The revocation registry delta.
+        /// </returns>
+        Task<ParseRegistryResponseResult> LookupRevocationRegistryDeltaAsync(IAgentContext agentContext, string revocationRegistryId,
             long from, long to);
 
         /// <summary>
         /// Lookup revocation registry for the given point in time.
         /// </summary>
-        /// <returns>The revocation registry async.</returns>
-        /// <param name="pool">Pool.</param>
+        /// <param name="agentContext">The agent context.</param>
         /// <param name="revocationRegistryId">Revocation registry identifier.</param>
         /// <param name="timestamp">Timestamp.</param>
-        Task<ParseRegistryResponseResult> LookupRevocationRegistryAsync(Pool pool, string revocationRegistryId,
+        /// <returns>
+        /// The revocation registry async.
+        /// </returns>
+        Task<ParseRegistryResponseResult> LookupRevocationRegistryAsync(IAgentContext agentContext, string revocationRegistryId,
             long timestamp);
 
         /// <summary>

--- a/src/Hyperledger.Aries/Ledger/DefaultLedgerService.cs
+++ b/src/Hyperledger.Aries/Ledger/DefaultLedgerService.cs
@@ -33,13 +33,13 @@ namespace Hyperledger.Aries.Ledger
         }
 
         /// <inheritdoc />
-        public virtual async Task<ParseResponseResult> LookupDefinitionAsync(Pool pool,
+        public virtual async Task<ParseResponseResult> LookupDefinitionAsync(IAgentContext agentContext,
             string definitionId)
         {
             async Task<ParseResponseResult> LookupDefinition()
             {
                 var req = await IndyLedger.BuildGetCredDefRequestAsync(null, definitionId);
-                var res = await IndyLedger.SubmitRequestAsync(pool, req);
+                var res = await IndyLedger.SubmitRequestAsync(await agentContext.Pool, req);
 
                 return await IndyLedger.ParseGetCredDefResponseAsync(res);
             }
@@ -50,22 +50,22 @@ namespace Hyperledger.Aries.Ledger
         }
 
         /// <inheritdoc />
-        public virtual async Task<ParseResponseResult> LookupRevocationRegistryDefinitionAsync(Pool pool,
+        public virtual async Task<ParseResponseResult> LookupRevocationRegistryDefinitionAsync(IAgentContext agentContext,
             string registryId)
         {
             var req = await IndyLedger.BuildGetRevocRegDefRequestAsync(null, registryId);
-            var res = await IndyLedger.SubmitRequestAsync(pool, req);
+            var res = await IndyLedger.SubmitRequestAsync(await agentContext.Pool, req);
 
             return await IndyLedger.ParseGetRevocRegDefResponseAsync(res);
         }
 
         /// <inheritdoc />
-        public virtual async Task<ParseResponseResult> LookupSchemaAsync(Pool pool, string schemaId)
+        public virtual async Task<ParseResponseResult> LookupSchemaAsync(IAgentContext agentContext, string schemaId)
         {
             async Task<ParseResponseResult> LookupSchema()
             {
                 var req = await IndyLedger.BuildGetSchemaRequestAsync(null, schemaId);
-                var res = await IndyLedger.SubmitRequestAsync(pool, req);
+                var res = await IndyLedger.SubmitRequestAsync(await agentContext.Pool, req);
 
                 EnsureSuccessResponse(res);
 
@@ -78,11 +78,11 @@ namespace Hyperledger.Aries.Ledger
         }
 
         /// <inheritdoc />
-        public virtual async Task<ParseRegistryResponseResult> LookupRevocationRegistryDeltaAsync(Pool pool, string revocationRegistryId,
+        public virtual async Task<ParseRegistryResponseResult> LookupRevocationRegistryDeltaAsync(IAgentContext agentContext, string revocationRegistryId,
              long from, long to)
         {
             var req = await IndyLedger.BuildGetRevocRegDeltaRequestAsync(null, revocationRegistryId, from, to);
-            var res = await IndyLedger.SubmitRequestAsync(pool, req);
+            var res = await IndyLedger.SubmitRequestAsync(await agentContext.Pool, req);
 
             EnsureSuccessResponse(res);
 
@@ -90,11 +90,11 @@ namespace Hyperledger.Aries.Ledger
         }
 
         /// <inheritdoc />
-        public virtual async Task<ParseRegistryResponseResult> LookupRevocationRegistryAsync(Pool pool, string revocationRegistryId,
+        public virtual async Task<ParseRegistryResponseResult> LookupRevocationRegistryAsync(IAgentContext agentContext, string revocationRegistryId,
              long timestamp)
         {
             var req = await IndyLedger.BuildGetRevocRegRequestAsync(null, revocationRegistryId, timestamp);
-            var res = await IndyLedger.SubmitRequestAsync(pool, req);
+            var res = await IndyLedger.SubmitRequestAsync(await agentContext.Pool, req);
 
             EnsureSuccessResponse(res);
 
@@ -144,19 +144,19 @@ namespace Hyperledger.Aries.Ledger
         }
 
         /// <inheritdoc />
-        public virtual async Task<string> LookupAttributeAsync(Pool pool, string targetDid, string attributeName)
+        public virtual async Task<string> LookupAttributeAsync(IAgentContext agentContext, string targetDid, string attributeName)
         {
             var req = await IndyLedger.BuildGetAttribRequestAsync(null, targetDid, attributeName, null, null);
-            var res = await IndyLedger.SubmitRequestAsync(pool, req);
+            var res = await IndyLedger.SubmitRequestAsync(await agentContext.Pool, req);
 
             return null;
         }
 
         /// <inheritdoc />
-        public virtual async Task<string> LookupTransactionAsync(Pool pool, string ledgerType, int sequenceId)
+        public virtual async Task<string> LookupTransactionAsync(IAgentContext agentContext, string ledgerType, int sequenceId)
         {
             var req = await IndyLedger.BuildGetTxnRequestAsync(null, ledgerType, sequenceId);
-            var res = await IndyLedger.SubmitRequestAsync(pool, req);
+            var res = await IndyLedger.SubmitRequestAsync(await agentContext.Pool, req);
 
             return res;
         }
@@ -172,10 +172,10 @@ namespace Hyperledger.Aries.Ledger
         }
 
         /// <inheritdoc />
-        public async Task<string> LookupNymAsync(Pool pool, string did)
+        public async Task<string> LookupNymAsync(IAgentContext agentContext, string did)
         {
             var req = await IndyLedger.BuildGetNymRequestAsync(null, did);
-            var res = await IndyLedger.SubmitRequestAsync(pool, req);
+            var res = await IndyLedger.SubmitRequestAsync(await agentContext.Pool, req);
 
             EnsureSuccessResponse(res);
 
@@ -183,10 +183,10 @@ namespace Hyperledger.Aries.Ledger
         }
 
         /// <inheritdoc />
-        public async Task<IList<AuthorizationRule>> LookupAuthorizationRulesAsync(Pool pool)
+        public async Task<IList<AuthorizationRule>> LookupAuthorizationRulesAsync(IAgentContext agentContext)
         {
             var req = await IndyLedger.BuildGetAuthRuleRequestAsync(null, null, null, null, null, null);
-            var res = await IndyLedger.SubmitRequestAsync(pool, req);
+            var res = await IndyLedger.SubmitRequestAsync(await agentContext.Pool, req);
 
             EnsureSuccessResponse(res);
 

--- a/test/Hyperledger.Aries.Tests/Payments/PaymentTests.cs
+++ b/test/Hyperledger.Aries.Tests/Payments/PaymentTests.cs
@@ -90,7 +90,7 @@ namespace Hyperledger.Aries.Tests.Payments
         {
             var ledgerService = Host.Services.GetService<ILedgerService>();
 
-            var rules = await ledgerService.LookupAuthorizationRulesAsync(await Context.Pool);
+            var rules = await ledgerService.LookupAuthorizationRulesAsync(Context);
 
             Assert.NotNull(rules);
             Assert.True(rules.Any());

--- a/test/Hyperledger.Aries.Tests/SchemaServiceTests.cs
+++ b/test/Hyperledger.Aries.Tests/SchemaServiceTests.cs
@@ -31,7 +31,7 @@ namespace Hyperledger.Aries.Tests
             await Task.Delay(TimeSpan.FromSeconds(5));
 
             //Resolve it from the ledger with its identifier
-            var resultSchema = await schemaService.LookupSchemaAsync(await Context.Pool, schemaId);
+            var resultSchema = await schemaService.LookupSchemaAsync(Context, schemaId);
 
             var resultSchemaName = JObject.Parse(resultSchema)["name"].ToString();
             var resultSchemaVersion = JObject.Parse(resultSchema)["version"].ToString();
@@ -41,7 +41,7 @@ namespace Hyperledger.Aries.Tests
             Assert.Equal(schemaVersion, resultSchemaVersion);
 
             //Resolve it from the ledger with its sequence Id
-            var secondResultSchema = await schemaService.LookupSchemaAsync(await Context.Pool, sequenceId);
+            var secondResultSchema = await schemaService.LookupSchemaAsync(Context, sequenceId);
 
             var secondResultSchemaName = JObject.Parse(secondResultSchema)["name"].ToString();
             var secondResultSchemaVersion = JObject.Parse(secondResultSchema)["version"].ToString();
@@ -78,13 +78,13 @@ namespace Hyperledger.Aries.Tests
             await Task.Delay(TimeSpan.FromSeconds(2));
 
             var credDef =
-                await schemaService.LookupCredentialDefinitionAsync(await Context.Pool, credId);
+                await schemaService.LookupCredentialDefinitionAsync(Context, credId);
 
             var resultCredId = JObject.Parse(credDef)["id"].ToString();
 
             Assert.Equal(credId, resultCredId);
 
-            var result = await schemaService.LookupSchemaFromCredentialDefinitionAsync(await Context.Pool, credId);
+            var result = await schemaService.LookupSchemaFromCredentialDefinitionAsync(Context, credId);
 
             var resultSchemaName = JObject.Parse(result)["name"].ToString();
             var resultSchemaVersion = JObject.Parse(result)["version"].ToString();


### PR DESCRIPTION
Signed-off-by: Tomislav Markovski <tomislav@streetcred.id>

This PR fixes an inconsistency in the use of AgentContext to pass the Pool parameter. Now all service method signatures use `IAgentContext` and call the Pool as needed internally.

This is a minor breaking change only for those who implement custom `ILedgerService`, `ISchemaService` or `ITailsService`