### PR TITLE
Add feature: automatically request credential offer and response cred…

### DIFF
--- a/samples/aspnetcore/Controllers/CredentialsController.cs
+++ b/samples/aspnetcore/Controllers/CredentialsController.cs
@@ -109,7 +109,11 @@ namespace WebAgent.Controllers
             var issuer = await _provisionService.GetProvisioningAsync(context.Wallet);
             var connection = await _connectionService.GetAsync(context, model.ConnectionId);
             var values = JsonConvert.DeserializeObject<List<CredentialPreviewAttribute>>(model.CredentialAttributes);
-            values.Add(new CredentialPreviewAttribute("issuer", issuer.Owner.Name));
+
+            foreach (CredentialPreviewAttribute attr in values)
+            {
+                attr.MimeType = CredentialMimeTypes.ApplicationJsonMimeType;
+            }
 
             var (offer, _) = await _credentialService.CreateOfferAsync(context, new OfferConfiguration
                 {

--- a/src/Hyperledger.Aries/Configuration/AgentOptions.cs
+++ b/src/Hyperledger.Aries/Configuration/AgentOptions.cs
@@ -147,5 +147,25 @@ namespace Hyperledger.Aries.Configuration
         /// The backup directory.
         /// </value>
         public string BackupDirectory { get; set; } = Path.Combine(Path.GetTempPath(), "AriesBackups");
+
+        /// <summary>
+        /// Automatically respond to credential offers with a credential request. Default: false
+        /// </summary>
+        /// <value>The name of the pool.</value>
+        public bool AutoRespondCredentialOffer
+        {
+            get;
+            set;
+        } = false;
+
+        /// <summary>
+        /// Automatically respond to credential request with corresponding credentials. Default: false
+        /// </summary>
+        /// <value>The name of the pool.</value>
+        public bool AutoRespondCredentialRequest
+        {
+            get;
+            set;
+        } = false;
     }
 }

--- a/src/Hyperledger.Aries/Features/IssueCredential/DefaultCredentialHandler.cs
+++ b/src/Hyperledger.Aries/Features/IssueCredential/DefaultCredentialHandler.cs
@@ -3,28 +3,34 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Hyperledger.Aries.Agents;
+using Hyperledger.Aries.Configuration;
 using Hyperledger.Aries.Extensions;
 using Hyperledger.Aries.Storage;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using Microsoft.Extensions.Options;
 
 namespace Hyperledger.Aries.Features.IssueCredential
 {
     internal class DefaultCredentialHandler : IMessageHandler
     {
+        private readonly AgentOptions _agentOptions;
         private readonly ICredentialService _credentialService;
         private readonly IWalletRecordService _recordService;
         private readonly IMessageService _messageService;
 
         /// <summary>Initializes a new instance of the <see cref="DefaultCredentialHandler"/> class.</summary>
+        /// <param name="agentOptions">The agent options.</param>
         /// <param name="credentialService">The credential service.</param>
         /// <param name="recordService">The wallet record service.</param>
         /// <param name="messageService">The message service.</param>
         public DefaultCredentialHandler(
+            IOptions<AgentOptions> agentOptions,
             ICredentialService credentialService,
             IWalletRecordService recordService,
             IMessageService messageService)
         {
+            _agentOptions = agentOptions.Value;
             _credentialService = credentialService;
             _recordService = recordService;
             _messageService = messageService;
@@ -63,6 +69,14 @@ namespace Hyperledger.Aries.Features.IssueCredential
 
                         messageContext.ContextRecord = await _credentialService.GetAsync(agentContext, recordId);
 
+                        // Auto request credential if set in the agent option
+                        if (_agentOptions.AutoRespondCredentialOffer == true)
+                        {
+                            var (message, record) = await _credentialService.CreateRequestAsync(agentContext, recordId);
+                            messageContext.ContextRecord = record;
+                            return message;
+                        }
+
                         return null;
                     }
 
@@ -81,6 +95,13 @@ namespace Hyperledger.Aries.Features.IssueCredential
                         }
                         else
                         {
+                            // Auto create credential if set in the agent option
+                            if (_agentOptions.AutoRespondCredentialRequest == true)
+                            {
+                                var (message, record) = await _credentialService.CreateCredentialAsync(agentContext, recordId);
+                                messageContext.ContextRecord = record;
+                                return message;
+                            }
                             messageContext.ContextRecord = await _credentialService.GetAsync(agentContext, recordId);
                             return null;
                         }


### PR DESCRIPTION
…ential request

#### Short description of what this resolves:
This enables credential holder can automatically request a credential when receive an offer, and also enable the issuer can automatically issue a new credential when receive a credential request from holder.

#### Changes proposed in this pull request:

- Added new agent options for automatically request credential and issue credential
- Updated credential controller in the sample core project to fixed two issue credential issues: first issue is "issuer" is not part of the credential schema, the second issue is the MimeType is null for credential attributes
- Update DefaultCredentialHandler.cs to have this automatic features

**Fixes**: #
