### PR TITLE
Clean up compiler warnings 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,7 +15,7 @@ tab_width = 4
 
 # New line preferences
 end_of_line = crlf
-insert_final_newline = false
+insert_final_newline = true
 
 # Development files
 [*.{cs,csx,cshtml,csproj,razor,sln,props,targets,json,md,yml,gitignore,}]

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+﻿# EditorConfig is awesome:http://EditorConfig.org
+# For dotnet and Csharp specific see below
+# https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference
+
+# Remove the line below if you want to inherit .editorconfig settings from higher directories
+root = true
+
+#### Core EditorConfig Options ####
+
+[*]
+# Indentation and spacing
+indent_size = 4
+indent_style = space
+tab_width = 4
+
+# New line preferences
+end_of_line = crlf
+insert_final_newline = false
+
+# Development files
+[*.{cs,csx,cshtml,csproj,razor,sln,props,targets,json,md,yml,gitignore,}]
+charset = "utf-8"

--- a/.editorconfig
+++ b/.editorconfig
@@ -20,3 +20,6 @@ insert_final_newline = true
 # Development files
 [*.{cs,csx,cshtml,csproj,razor,sln,props,targets,json,md,yml,gitignore,}]
 charset = "utf-8"
+
+# CS1591: Missing XML comment for publicly visible type or member
+dotnet_diagnostic.CS1591.severity = suggestion

--- a/src/Hyperledger.Aries.Routing.Edge/AriesFrameworkBuilderExtensions.cs
+++ b/src/Hyperledger.Aries.Routing.Edge/AriesFrameworkBuilderExtensions.cs
@@ -14,24 +14,29 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </summary>
         /// <param name="builder"></param>
         /// <param name="options"></param>
+        /// <param name="delayProvisioning"></param>
         /// <returns></returns>
-        public static AriesFrameworkBuilder RegisterEdgeAgent(
+        public static AriesFrameworkBuilder RegisterEdgeAgent
+        (
             this AriesFrameworkBuilder builder,
             Action<AgentOptions> options,
             bool delayProvisioning = false)
-            => RegisterEdgeAgent<DefaultAgent>(builder, options, delayProvisioning);
+            => RegisterEdgeAgent<DefaultAgent>(builder, options, delayProvisioning
+        );
 
         /// <summary>
         /// Registers and provisions an agent with custom implementation
         /// </summary>
         /// <param name="builder"></param>
         /// <param name="options"></param>
+        /// <param name="delayProvisioning"></param>
         /// <returns></returns>
-        public static AriesFrameworkBuilder RegisterEdgeAgent<T>(
+        public static AriesFrameworkBuilder RegisterEdgeAgent<T>
+        (
             this AriesFrameworkBuilder builder,
             Action<AgentOptions> options,
-            bool delayProvisioning = false)
-            where T : class, IAgent
+            bool delayProvisioning = false
+        ) where T : class, IAgent
         {
             builder.AddAgentProvider();
             builder.Services.AddDefaultMessageHandlers();

--- a/src/Hyperledger.Aries.Routing.Edge/EdgeClientService.cs
+++ b/src/Hyperledger.Aries.Routing.Edge/EdgeClientService.cs
@@ -120,7 +120,7 @@ namespace Hyperledger.Aries.Routing.Edge
                     await agentContext.Agent.ProcessAsync(agentContext, new PackedMessageContext(item.Data));
                     processedItems.Add(item.Id);
                 }
-                catch (Exception e)
+                catch (Exception)
                 {
                     unprocessedItem.Add(item);
                 }

--- a/src/Hyperledger.Aries.TestHarness/Scenarios.cs
+++ b/src/Hyperledger.Aries.TestHarness/Scenarios.cs
@@ -186,8 +186,8 @@ namespace Hyperledger.TestHarness
             Console.WriteLine(requestorProofProposalRecord.ProposalJson);
             // Requestor sends a proof request
             var (requestorRequestMessage, requestorProofRequestRecord) = await proofService.CreateRequestFromProposalAsync(
-                requestorContext, 
-                new ProofRequestParameters 
+                requestorContext,
+                new ProofRequestParameters
                 {
                     Name = "Test",
                     Version = "1.0"
@@ -231,7 +231,7 @@ namespace Hyperledger.TestHarness
             Assert.Equal(ProofState.Requested, holderProofRecord.State);
             Console.WriteLine(holderProofRecord.RequestJson);
 
-            
+
             var holderProofRequest = JsonConvert.DeserializeObject<ProofRequest>(holderProofRecord.RequestJson);
 
             // Auto satisfy the proof with which ever credentials in the wallet are capable
@@ -268,8 +268,19 @@ namespace Hyperledger.TestHarness
         {
             // Create a schema and credential definition for this issuer
             var schemaId = await schemaService.CreateSchemaAsync(context, issuerDid,
-                $"Test-Schema-{Guid.NewGuid().ToString()}", "1.0", attributeValues);
-            return (await schemaService.CreateCredentialDefinitionAsync(context, schemaId, issuerDid, "Tag", false, 100, new Uri("http://mock/tails")), schemaId);
+                $"Test-Schema-{Guid.NewGuid()}", "1.0", attributeValues);
+            var credentialDefinitionConfiguration = new CredentialDefinitionConfiguration
+            {
+                SchemaId = schemaId,
+                EnableRevocation = false,
+                IssuerDid = issuerDid,
+                Tag = "Tag",
+            };
+            return
+            (
+                await schemaService.CreateCredentialDefinitionAsync(context, credentialDefinitionConfiguration),
+                schemaId
+            );
         }
 
         private static T FindContentMessage<T>(IEnumerable<AgentMessage> collection)

--- a/src/Hyperledger.Aries/Features/PresentProof/IProofService.cs
+++ b/src/Hyperledger.Aries/Features/PresentProof/IProofService.cs
@@ -19,7 +19,6 @@ namespace Hyperledger.Aries.Features.PresentProof
         /// <returns>The proof proposal.</returns>
         /// <param name="agentContext">Agent Context.</param>
         /// <param name="proofProposal">The proof proposal that will be created</param>
-        /// <param name="predicates">An enumeration of predicates that we wish the verifier to request.</param>
         /// <param name="connectionId">Connection identifier of who the proof request will be sent to.</param>
         /// <returns>Proof Request message and identifier.</returns>
         Task<(ProposePresentationMessage, ProofRecord)> CreateProposalAsync(IAgentContext agentContext,
@@ -31,14 +30,14 @@ namespace Hyperledger.Aries.Features.PresentProof
         /// </summary>
         /// <returns>The proof request.</returns>
         /// <param name="agentContext">Agent Context.</param>
-        /// <param name="proofRequestParamesters">The parameters needed to generate a request from the proposal</param>
+        /// <param name="requestParameters">The parameters requested to be proven</param>
         /// <param name="proofRecordId">proposal Id</param>
         /// <param name="connectionId">Connection identifier of who the proof proposal will be sent to.</param>
         /// <returns>Proof Request message and identifier.</returns>
         Task<(RequestPresentationMessage, ProofRecord)> CreateRequestFromProposalAsync(IAgentContext agentContext, ProofRequestParameters requestParameters,
             string proofRecordId, string connectionId);
 
-        
+
         /// <summary>
         /// Processes a proof proposal and stores it for a given connection.
         /// </summary>
@@ -111,7 +110,7 @@ namespace Hyperledger.Aries.Features.PresentProof
         /// </returns>
         Task<string> CreatePresentationAsync(
             IAgentContext agentContext,
-            ProofRequest proofRequest, 
+            ProofRequest proofRequest,
             RequestedCredentials requestedCredentials);
 
         /// <summary>
@@ -195,7 +194,7 @@ namespace Hyperledger.Aries.Features.PresentProof
         /// </returns>
         Task<List<Credential>> ListCredentialsForProofRequestAsync(
             IAgentContext agentContext,
-            ProofRequest proofRequest, 
+            ProofRequest proofRequest,
             string attributeReferent);
     }
 }

--- a/src/Hyperledger.Aries/Features/PresentProof/Messages/PresentationPreview.cs
+++ b/src/Hyperledger.Aries/Features/PresentProof/Messages/PresentationPreview.cs
@@ -117,8 +117,9 @@ namespace Hyperledger.Aries.Features.PresentProof
         [JsonProperty("schema_id")]
         public string SchemaId { get; set; }
 
+        // Gets or sets the predicate operator (>, >=, <, <=)
         /// <summary>
-        /// Gets or sets the predicate operator (>, >=, <, <=)
+        /// Gets or sets the predicate operator (>, >=, &lt;, &lt;=) 
         /// </summary>
         [JsonProperty("predicate")]
         public string Predicate { get; set; }

--- a/test/.editorconfig
+++ b/test/.editorconfig
@@ -1,0 +1,11 @@
+﻿# EditorConfig is awesome:http://EditorConfig.org
+# For dotnet and Csharp specific see below
+# https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference
+
+# Set root = false if you want to inherit .editorconfig settings from parent directories
+root = false
+
+[*.cs]
+# CS0618: Type or member is obsolete
+# we still need to test obsolete items until they are removed
+dotnet_diagnostic.CS0618.severity = none


### PR DESCRIPTION
#### Short description of what this resolves:
Eliminate compiler warnings.

#### Changes proposed in this pull request:
Changed the Missing XML comment from a warning to a suggestion.
Suppress the warning about calling obsolete in tests.  We still have to test them until removed.
Fixed some XML comments that had missing or incorrect parameters.
Removed unused param.

Replaced 1 obsolete function call with the recommended replacement.

Currently builds with no warnings.
