### PR TITLE
Restore wallet different configuration1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
         <Product>Hyperledger Aries Dotnet</Product>
         <RepositoryUrl>https://github.com/hyperledger/aries-framework-dotnet.git</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
-        <Version>1.3.2</Version>
+        <Version>1.3.3</Version>
     </PropertyGroup>
 
     <!-- Common compile parameters -->

--- a/src/Hyperledger.Aries.Routing.Edge/IEdgeClientService.cs
+++ b/src/Hyperledger.Aries.Routing.Edge/IEdgeClientService.cs
@@ -85,8 +85,7 @@ namespace Hyperledger.Aries.Routing
         Task<List<long>> ListBackupsAsync(IAgentContext context);
 
         /// <summary>
-        /// Restores the agent and wallet from backup. Removes the existing wallet and creates a new one with same
-        /// configuration
+        /// Restores the agent and wallet from backup with a given attachment
         /// </summary>
         /// <param name="edgeContext">The edge context.</param>
         /// <param name="seed">The seed.</param>
@@ -96,8 +95,8 @@ namespace Hyperledger.Aries.Routing
         Task RestoreFromBackupAsync(IAgentContext edgeContext, string seed, List<Attachment> backupData);
 
         /// <summary>
-        /// Restores the agent and wallet from backup. Removes the existing wallet and creates a new one with same
-        /// configuration
+        /// Restores the agent and wallet from backup. Imports the wallet with new configuration and restores
+        /// the data. Tries to remove the existing wallet.
         /// </summary>
         /// <param name="edgeContext">The edge context.</param>
         /// <param name="seed">The seed.</param>

--- a/src/Hyperledger.Aries.Routing/Utils.cs
+++ b/src/Hyperledger.Aries.Routing/Utils.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Hyperledger.Aries.Routing
+{
+    public static class Utils
+    {
+        public static string GenerateRandomAsync(int maxSize)
+        {
+            var chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890".ToCharArray();
+            var data = new byte[maxSize];
+            using (var crypto = new RNGCryptoServiceProvider())
+            {
+                crypto.GetNonZeroBytes(data);
+            }
+
+            var result = new StringBuilder(maxSize);
+            foreach (var b in data)
+            {
+                result.Append(chars[b % (chars.Length)]);
+            }
+
+            return result.ToString();
+        }
+    }
+}


### PR DESCRIPTION
#### Short description of what this resolves:
Import the wallet with new configuration
DeleteWallet is after the importAsync method wrapped in try/catch block as it inconsistently fails on Android.
Utils created with GenerateRandomAsync method as Hyoerkedger.Utils CryptoUtils class is internal.

#### Changes proposed in this pull request:

-
-
-

**Fixes**: #
Android that fails on deleteWalletAsync no longer goes into limbo state
Importing is now done with new configuration passed on with agentOptions 
