### PR TITLE
Set id and type for CreateInboxResponseMessage

### DIFF
--- a/src/Hyperledger.Aries.Routing/CreateInboxResponseMessage.cs
+++ b/src/Hyperledger.Aries.Routing/CreateInboxResponseMessage.cs
@@ -1,4 +1,5 @@
 ﻿using Hyperledger.Aries.Agents;
+using System;
 
 namespace Hyperledger.Aries.Routing
 {

--- a/src/Hyperledger.Aries.Routing/CreateInboxResponseMessage.cs
+++ b/src/Hyperledger.Aries.Routing/CreateInboxResponseMessage.cs
@@ -5,6 +5,15 @@ namespace Hyperledger.Aries.Routing
     public class CreateInboxResponseMessage : AgentMessage
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="CreateInboxResponseMessage"/> class.
+        /// </summary>
+        public CreateInboxResponseMessage()
+        {
+            Id = Guid.NewGuid().ToString();
+            Type = RoutingTypeNames.CreateInboxResponseMessage;
+        }
+
+        /// <summary>
         /// Gets or sets the inbox identifier.
         /// </summary>
         /// <value>


### PR DESCRIPTION
#### Short description of what this resolves:
`CreateInboxResponseMessage` does not have `@id` and `@type` agent message properties set. This can cause issues for a generic agent message handler that uses `@type` for delegating message handling to a specific handler.

#### Changes proposed in this pull request:

- Set random ID and correct type from `RoutingTypeNames` in `CreateInboxResponseMessage` constructor

**Fixes**: #

Would it also make sense to add a thread decorator referring back to the initial `CreateInboxMessage`? That would be more in line with Aries RFCs, but creating an inbox is generally using duplex communication, so it seems redundant.
