### PR TITLE
Using GetAsync method instead of ListAsync method for getting credent…

### DIFF
--- a/src/Hyperledger.Aries.AspNetCore/Features/Credential/GetCredential/GetCredentialHandler.cs
+++ b/src/Hyperledger.Aries.AspNetCore/Features/Credential/GetCredential/GetCredentialHandler.cs
@@ -28,12 +28,8 @@ namespace Hyperledger.Aries.AspNetCore.Features.Credentials
     {
 
       IAgentContext agentContext = await AgentProvider.GetContextAsync();
-      List<CredentialRecord> credentialRecords = await CredentialService.ListAsync(agentContext);
-
-      CredentialRecord credentialRecord =
-        credentialRecords
-          .FirstOrDefault(aCredentialRecord => aCredentialRecord.CredentialId == aGetCredentialRequest.CredentialId);
-
+      CredentialRecord credentialRecord = await CredentialService.GetAsync(agentContext, aGetCredentialRequest.CredentialId);
+      
       var response = new GetCredentialResponse(aGetCredentialRequest.CorrelationId, credentialRecord);
 
       return response;


### PR DESCRIPTION
@tmarkovski  @StevenTCramer 

#### Short description of what this resolves:
Enhancement in code- Update in class **GetCredentialHandler**


#### Changes proposed in this pull request:
Use GetAsync() method instead of ListAsync() method


**Fixes**: https://github.com/hyperledger/aries-framework-dotnet/issues/132
