### PR TITLE
Add pagination support for SearchAsync

### DIFF
--- a/src/Hyperledger.Aries/Features/DidExchange/DefaultConnectionService.cs
+++ b/src/Hyperledger.Aries/Features/DidExchange/DefaultConnectionService.cs
@@ -322,11 +322,11 @@ namespace Hyperledger.Aries.Features.DidExchange
 
         /// <inheritdoc />
         public virtual Task<List<ConnectionRecord>> ListAsync(IAgentContext agentContext, ISearchQuery query = null,
-            int count = 100)
+            int count = 100, int skip = 0)
         {
             Logger.LogTrace(LoggingEvents.ListConnections, "List Connections");
 
-            return RecordService.SearchAsync<ConnectionRecord>(agentContext.Wallet, query, null, count);
+            return RecordService.SearchAsync<ConnectionRecord>(agentContext.Wallet, query, null, count, skip);
         }
 
         /// <inheritdoc />

--- a/src/Hyperledger.Aries/Features/DidExchange/IConnectionService.cs
+++ b/src/Hyperledger.Aries/Features/DidExchange/IConnectionService.cs
@@ -27,7 +27,8 @@ namespace Hyperledger.Aries.Features.DidExchange
         /// <param name="agentContext">Agent Context.</param>
         /// <param name="query">The query used to filter the search results.</param>
         /// <param name="count">The maximum item count of items to return to return.</param>
-        Task<List<ConnectionRecord>> ListAsync(IAgentContext agentContext, ISearchQuery query = null, int count = 100);
+        /// <param name="skip">The number of items to skip.</param>
+        Task<List<ConnectionRecord>> ListAsync(IAgentContext agentContext, ISearchQuery query = null, int count = 100, int skip = 0);
 
         /// <summary>
         /// Creates the invitation asynchronous.

--- a/src/Hyperledger.Aries/Features/IssueCredential/Abstractions/ICredentialService.cs
+++ b/src/Hyperledger.Aries/Features/IssueCredential/Abstractions/ICredentialService.cs
@@ -26,8 +26,9 @@ namespace Hyperledger.Aries.Features.IssueCredential
         /// <param name="agentContext">Agent Context.</param>
         /// <param name="query">The query.</param>
         /// <param name="count">The number of items to return</param>
+        /// <param name="skip">The number of items to skip</param>
         /// <returns>A list of credential records matching the search criteria</returns>
-        Task<List<CredentialRecord>> ListAsync(IAgentContext agentContext, ISearchQuery query = null, int count = 100);
+        Task<List<CredentialRecord>> ListAsync(IAgentContext agentContext, ISearchQuery query = null, int count = 100, int skip = 0);
 
         /// <summary>
         /// Process the offer and stores in the designated wallet asynchronous.

--- a/src/Hyperledger.Aries/Features/IssueCredential/DefaultCredentialService.cs
+++ b/src/Hyperledger.Aries/Features/IssueCredential/DefaultCredentialService.cs
@@ -130,8 +130,8 @@ namespace Hyperledger.Aries.Features.IssueCredential
 
         /// <inheritdoc />
         public virtual Task<List<CredentialRecord>> ListAsync(IAgentContext agentContext, ISearchQuery query = null,
-            int count = 100) =>
-            RecordService.SearchAsync<CredentialRecord>(agentContext.Wallet, query, null, count);
+            int count = 100, int skip = 0) =>
+            RecordService.SearchAsync<CredentialRecord>(agentContext.Wallet, query, null, count, skip);
 
         /// <inheritdoc />
         public virtual async Task RejectOfferAsync(IAgentContext agentContext, string credentialId)

--- a/src/Hyperledger.Aries/Storage/DefaultWalletRecordService.cs
+++ b/src/Hyperledger.Aries/Storage/DefaultWalletRecordService.cs
@@ -47,15 +47,15 @@ namespace Hyperledger.Aries.Storage
         }
 
         /// <inheritdoc />
-        public virtual async Task<List<T>> SearchAsync<T>(Wallet wallet, ISearchQuery query, SearchOptions options, int count)
+        public virtual async Task<List<T>> SearchAsync<T>(Wallet wallet, ISearchQuery query, SearchOptions options, int count, int skip)
             where T : RecordBase, new()
         {
             using (var search = await NonSecrets.OpenSearchAsync(wallet, new T().TypeName,
                 (query ?? SearchQuery.Empty).ToJson(),
                 (options ?? new SearchOptions()).ToJson()))
             {
+                await search.NextAsync(wallet, skip);
                 var result = JsonConvert.DeserializeObject<SearchResult>(await search.NextAsync(wallet, count), _jsonSettings);
-                // TODO: Add support for pagination
 
                 return result.Records?
                            .Select(x =>

--- a/src/Hyperledger.Aries/Storage/IWalletRecordService.cs
+++ b/src/Hyperledger.Aries/Storage/IWalletRecordService.cs
@@ -26,8 +26,9 @@ namespace Hyperledger.Aries.Storage
         /// <param name="query">Query.</param>
         /// <param name="options">Options.</param>
         /// <param name="count">The number of items to return</param>
+        /// <param name="skip">The number of items to skip</param>
         /// <typeparam name="T">The 1st type parameter.</typeparam>
-        Task<List<T>> SearchAsync<T>(Wallet wallet, ISearchQuery query = null, SearchOptions options = null, int count = 10) where T : RecordBase, new();
+        Task<List<T>> SearchAsync<T>(Wallet wallet, ISearchQuery query = null, SearchOptions options = null, int count = 10, int skip = 0) where T : RecordBase, new();
 
         /// <summary>
         /// Updates the record async.


### PR DESCRIPTION
#### Short description of what this resolves:

Add simple pagination in the `DefaultWalletRecordService`

#### Changes proposed in this pull request:

- add `skip` parameter to the `SearchAsync` method
