### PR TITLE
Check if a credential is revoked against the ledger state

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
         <Product>Hyperledger Aries Dotnet</Product>
         <RepositoryUrl>https://github.com/hyperledger/aries-framework-dotnet.git</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
-        <Version>1.4.0</Version>
+        <Version>1.5.0</Version>
     </PropertyGroup>
 
     <!-- Common compile parameters -->

--- a/src/Hyperledger.Aries/Features/IssueCredential/DefaultCredentialService.cs
+++ b/src/Hyperledger.Aries/Features/IssueCredential/DefaultCredentialService.cs
@@ -24,6 +24,7 @@ using Hyperledger.Aries.Payments;
 using Hyperledger.Aries.Storage;
 using Hyperledger.Indy;
 using Polly;
+using Hyperledger.Aries.Features.PresentProof;
 
 namespace Hyperledger.Aries.Features.IssueCredential
 {

--- a/src/Hyperledger.Aries/Features/PresentProof/IProofService.cs
+++ b/src/Hyperledger.Aries/Features/PresentProof/IProofService.cs
@@ -151,6 +151,34 @@ namespace Hyperledger.Aries.Features.PresentProof
         Task<bool> VerifyProofAsync(IAgentContext agentContext, string proofRecordId);
 
         /// <summary>
+        /// Check if a credential has been revoked by validating against the revocation state
+        /// on the ledger.
+        /// </summary>
+        /// <remarks>
+        /// This method can be used as a holder, to check if a credential thay own has been
+        /// revoked by the issuer. If a credential doesn't support revocation, this method will
+        /// always return <c>false</c>
+        /// </remarks>
+        /// <param name="context"></param>
+        /// <param name="record"></param>
+        /// <returns></returns>
+        Task<bool> IsRevokedAsync(IAgentContext context, CredentialRecord record);
+
+        /// <summary>
+        /// Check if a credential has been revoked by validating against the revocation state
+        /// on the ledger.
+        /// </summary>
+        /// <remarks>
+        /// This method can be used as a holder, to check if a credential thay own has been
+        /// revoked by the issuer. If a credential doesn't support revocation, this method will
+        /// always return <c>false</c>
+        /// </remarks>
+        /// <param name="context"></param>
+        /// <param name="credentialRecordId"></param>
+        /// <returns></returns>
+        Task<bool> IsRevokedAsync(IAgentContext context, string credentialRecordId);
+
+        /// <summary>
         /// Verifies a proof.
         /// </summary>
         /// <param name="agentContext">Agent Context.</param>


### PR DESCRIPTION
Add a method in proof service that checks if a credential has been revoked. Can be used by a holder of a credential.