### PR TITLE
Removed filter for non-revocable creds in ListCredentialsForProofRequest

### DIFF
--- a/src/Hyperledger.Aries/Features/PresentProof/DefaultProofService.cs
+++ b/src/Hyperledger.Aries/Features/PresentProof/DefaultProofService.cs
@@ -307,13 +307,7 @@ namespace Hyperledger.Aries.Features.PresentProof
                 await AnonCreds.ProverSearchCredentialsForProofRequestAsync(agentContext.Wallet, proofRequest.ToJson()))
             {
                 var searchResult = await search.NextAsync(attributeReferent, 100);
-                var result = JsonConvert.DeserializeObject<List<Credential>>(searchResult);
-
-                if (proofRequest.NonRevoked != null)
-                {
-                    return result.Where(x => x.CredentialInfo.RevocationRegistryId != null).ToList();
-                }
-                return result;
+                return JsonConvert.DeserializeObject<List<Credential>>(searchResult);
             }
         }
 


### PR DESCRIPTION
Signed-off-by: Sebastian Bickerle <sebastian.bickerle@main-incubator.com>

#### Short description of what this resolves:
Removes the filtering of non-revocable credentials from proof requests with a NonRevoked interval

This allows proof requests with a NonRevoked interval to be answered with revocable and non-revocable credentials as it is supported by indy

#### Changes proposed in this pull request:

- Remove the where clause from the default ListCredentialsForProofRequestAsync method
