### PR TITLE
Add support for using PostgreSQL database for mediator agent inbox records

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
         <Product>Hyperledger Aries Dotnet</Product>
         <RepositoryUrl>https://github.com/hyperledger/aries-framework-dotnet.git</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
-        <Version>1.5.2</Version>
+        <Version>1.5.3</Version>
     </PropertyGroup>
 
     <!-- Common compile parameters -->

--- a/src/Hyperledger.Aries.Routing.Mediator/Handlers/RoutingInboxHandler.cs
+++ b/src/Hyperledger.Aries.Routing.Mediator/Handlers/RoutingInboxHandler.cs
@@ -45,8 +45,8 @@ namespace Hyperledger.Aries.Routing
 
         public async Task<AgentMessage> ProcessAsync(IAgentContext agentContext, UnpackedMessageContext messageContext)
         {
-            if (messageContext.Connection == null || 
-                messageContext.Connection.MultiPartyInvitation || 
+            if (messageContext.Connection == null ||
+                messageContext.Connection.MultiPartyInvitation ||
                 messageContext.Connection.State != ConnectionState.Connected)
             {
                 throw new InvalidOperationException("Connection is missing or invalid");
@@ -166,9 +166,14 @@ namespace Hyperledger.Aries.Routing
                 WalletConfiguration = new WalletConfiguration
                 {
                     Id = inboxId,
-                    StorageType = options.WalletConfiguration?.StorageType ?? "default"
+                    StorageType = options.WalletConfiguration?.StorageType ?? "default",
+                    StorageConfiguration = options.WalletConfiguration?.StorageConfiguration
                 },
-                WalletCredentials = new WalletCredentials { Key = inboxKey }
+                WalletCredentials = new WalletCredentials
+                {
+                    Key = inboxKey,
+                    StorageCredentials = options.WalletCredentials?.StorageCredentials
+                }
             };
             connection.SetTag("InboxId", inboxId);
 

--- a/src/Hyperledger.Aries/Storage/Models/WalletCredentials.cs
+++ b/src/Hyperledger.Aries/Storage/Models/WalletCredentials.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using System.Text.Json.Serialization;
 
 namespace Hyperledger.Aries.Storage

--- a/src/Hyperledger.Aries/Storage/Models/WalletStorageConfiguration.cs
+++ b/src/Hyperledger.Aries/Storage/Models/WalletStorageConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 
 namespace Hyperledger.Aries.Storage
 {
@@ -16,10 +16,26 @@ namespace Hyperledger.Aries.Storage
             [JsonProperty("path")]
             public string Path { get; set; }
 
+            /// <summary>
+            /// Gets or sets the database host url.
+            /// </summary>
+            /// <value>The url.</value>
+            [JsonProperty("url")]
+            public string Url { get; set; }
+
+            /// <summary>
+            /// Gets or sets the database wallet scheme.
+            /// </summary>
+            /// <value>The wallet scheme.</value>
+            [JsonProperty("wallet_scheme")]
+            public string WalletScheme { get; set; }
+
             /// <inheritdoc />
             public override string ToString() =>
                 $"{GetType().Name}: " +
-                $"Path={Path}";
+                $"Path={Path}" +
+                $"Url={Url}" +
+                $"WalletScheme={WalletScheme}";
         }
     }
 }

--- a/test/Hyperledger.Aries.Tests/Routing/RoutingInboxHandlerTests.cs
+++ b/test/Hyperledger.Aries.Tests/Routing/RoutingInboxHandlerTests.cs
@@ -95,15 +95,13 @@ namespace Hyperledger.Aries.Tests.Routing
                     StorageCredentials = storageCredentials
                 }
             } );
-
-            routingInboxHandler = new RoutingInboxHandler(recordService.Object, walletService.Object, routingStore.Object, options, logger.Object);
-
             UnpackedMessageContext unpackedMessage = new UnpackedMessageContext(
                 new CreateInboxMessage(),
                 new ConnectionRecord()
                 {
                     State = ConnectionState.Connected,
                 });
+            routingInboxHandler = new RoutingInboxHandler(recordService.Object, walletService.Object, routingStore.Object, options, logger.Object);
 
             CreateInboxResponseMessage agentMessage = (CreateInboxResponseMessage) await routingInboxHandler.ProcessAsync(agentContext.Object, unpackedMessage);
 

--- a/test/Hyperledger.Aries.Tests/Routing/RoutingInboxHandlerTests.cs
+++ b/test/Hyperledger.Aries.Tests/Routing/RoutingInboxHandlerTests.cs
@@ -22,7 +22,7 @@ namespace Hyperledger.Aries.Tests.Routing
         private readonly Mock<IRoutingStore> routingStore;
         private readonly Mock<IAgentContext> agentContext;
         private readonly Mock<ILogger<RoutingInboxHandler>> logger;
-        private readonly RoutingInboxHandler routingInboxHandler;
+        private RoutingInboxHandler routingInboxHandler;
 
         public RoutingInboxHandlerTests()
         {
@@ -75,6 +75,46 @@ namespace Hyperledger.Aries.Tests.Routing
             walletService.Verify(w => w.CreateWalletAsync(It.Is<WalletConfiguration>(wc => wc.Id == agentMessage.InboxId), It.Is<WalletCredentials>(wc => wc.Key == agentMessage.InboxKey)));
             recordService.Verify(m => m.AddAsync(agentContext.Object.Wallet, It.Is<InboxRecord>(i => i.GetTag(key) == value)), Times.Once());
             recordService.Verify(m => m.UpdateAsync(agentContext.Object.Wallet, It.Is<ConnectionRecord>(c => c.GetTag("InboxId") == agentMessage.InboxId)));
+        }
+
+        [Fact(DisplayName = "Create inbox method should create wallet record with storage configuration and credentials")]
+        public async Task CreateInboxRecordWithStorageConfigurationAndCredentialsAsync()
+        {
+            object storageCredentials = new {};
+            WalletConfiguration.WalletStorageConfiguration storageConfiguration = new WalletConfiguration.WalletStorageConfiguration();
+            string storageType = "postgres_storage";
+            IOptions<AgentOptions> options = Options.Create<AgentOptions>(new AgentOptions()
+            {
+                WalletConfiguration = new WalletConfiguration()
+                {
+                    StorageType = storageType,
+                    StorageConfiguration = storageConfiguration
+                },
+                WalletCredentials = new WalletCredentials()
+                {
+                    StorageCredentials = storageCredentials
+                }
+            } );
+
+            routingInboxHandler = new RoutingInboxHandler(recordService.Object, walletService.Object, routingStore.Object, options, logger.Object);
+
+            UnpackedMessageContext unpackedMessage = new UnpackedMessageContext(
+                new CreateInboxMessage(),
+                new ConnectionRecord()
+                {
+                    State = ConnectionState.Connected,
+                });
+
+            CreateInboxResponseMessage agentMessage = (CreateInboxResponseMessage) await routingInboxHandler.ProcessAsync(agentContext.Object, unpackedMessage);
+
+            walletService.Verify(w => w.CreateWalletAsync(It.Is<WalletConfiguration>(wc =>
+                wc.Id == agentMessage.InboxId
+                && wc.StorageConfiguration == storageConfiguration
+                && wc.StorageType == storageType
+                ), It.Is<WalletCredentials>(wc =>
+                wc.Key == agentMessage.InboxKey
+                && wc.StorageCredentials == storageCredentials
+            )));
         }
     }
 }

--- a/test/Hyperledger.Aries.Tests/Storage/Models/WalletStorageConfigurationTest.cs
+++ b/test/Hyperledger.Aries.Tests/Storage/Models/WalletStorageConfigurationTest.cs
@@ -9,9 +9,9 @@ namespace Hyperledger.Aries.Tests.Storage.Models
         private const string Path = "Path";
         private const string Url = "Url";
         private const string WalletScheme = "WalletScheme";
-        
-        [Fact(DisplayName = "Create wallet configuration model should correctly set and stringify all parameters")]
-        public void CreateInboxRecordAsync()
+
+        [Fact(DisplayName = "Wallet configuration model should correctly set and stringify all parameters")]
+        public void WalletStorageConfigurationModel()
         {
             WalletConfiguration.WalletStorageConfiguration walletStorageConfiguration = new WalletConfiguration.WalletStorageConfiguration()
             {
@@ -25,7 +25,7 @@ namespace Hyperledger.Aries.Tests.Storage.Models
             walletStorageConfiguration.WalletScheme.Should().Be(WalletScheme);
             walletStorageConfiguration.ToString().Should().Be(
                 "WalletStorageConfiguration: " +
-                $"Path={Path}" + 
+                $"Path={Path}" +
                 $"Url={Url}" +
                 $"WalletScheme={WalletScheme}");
         }

--- a/test/Hyperledger.Aries.Tests/Storage/Models/WalletStorageConfigurationTest.cs
+++ b/test/Hyperledger.Aries.Tests/Storage/Models/WalletStorageConfigurationTest.cs
@@ -1,0 +1,33 @@
+using FluentAssertions;
+using Hyperledger.Aries.Storage;
+using Xunit;
+
+namespace Hyperledger.Aries.Tests.Storage.Models
+{
+    public class WalletStorageConfigurationTest
+    {
+        private const string Path = "Path";
+        private const string Url = "Url";
+        private const string WalletScheme = "WalletScheme";
+        
+        [Fact(DisplayName = "Create wallet configuration model should correctly set and stringify all parameters")]
+        public void CreateInboxRecordAsync()
+        {
+            WalletConfiguration.WalletStorageConfiguration walletStorageConfiguration = new WalletConfiguration.WalletStorageConfiguration()
+            {
+                Path = Path,
+                Url = Url,
+                WalletScheme = WalletScheme
+            };
+
+            walletStorageConfiguration.Path.Should().Be(Path);
+            walletStorageConfiguration.Url.Should().Be(Url);
+            walletStorageConfiguration.WalletScheme.Should().Be(WalletScheme);
+            walletStorageConfiguration.ToString().Should().Be(
+                "WalletStorageConfiguration: " +
+                $"Path={Path}" + 
+                $"Url={Url}" +
+                $"WalletScheme={WalletScheme}");
+        }
+    }
+}


### PR DESCRIPTION
#### Short description of what this resolves:

Added support for storing inbox records using the Postgres storage plugin on the Mediator agent.

#### Changes proposed in this pull request:

- Add an ability to correctly propagate storage credentials and storage configuration used for the Postgres plugin.
- Bump NuGet package version

**Fixes**: #
