### PR TITLE
Add support for using PostgreSQL database for storing mediator agent inbox records

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
         <Product>Hyperledger Aries Dotnet</Product>
         <RepositoryUrl>https://github.com/hyperledger/aries-framework-dotnet.git</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
-        <Version>1.5.2</Version>
+        <Version>1.5.3</Version>
     </PropertyGroup>
 
     <!-- Common compile parameters -->

--- a/src/Hyperledger.Aries.Routing.Mediator/Handlers/RoutingInboxHandler.cs
+++ b/src/Hyperledger.Aries.Routing.Mediator/Handlers/RoutingInboxHandler.cs
@@ -45,8 +45,8 @@ namespace Hyperledger.Aries.Routing
 
         public async Task<AgentMessage> ProcessAsync(IAgentContext agentContext, UnpackedMessageContext messageContext)
         {
-            if (messageContext.Connection == null || 
-                messageContext.Connection.MultiPartyInvitation || 
+            if (messageContext.Connection == null ||
+                messageContext.Connection.MultiPartyInvitation ||
                 messageContext.Connection.State != ConnectionState.Connected)
             {
                 throw new InvalidOperationException("Connection is missing or invalid");
@@ -166,9 +166,14 @@ namespace Hyperledger.Aries.Routing
                 WalletConfiguration = new WalletConfiguration
                 {
                     Id = inboxId,
-                    StorageType = options.WalletConfiguration?.StorageType ?? "default"
+                    StorageType = options.WalletConfiguration?.StorageType ?? "default",
+                    StorageConfiguration = options.WalletConfiguration?.StorageConfiguration
                 },
-                WalletCredentials = new WalletCredentials { Key = inboxKey }
+                WalletCredentials = new WalletCredentials
+                {
+                    Key = inboxKey,
+                    StorageCredentials = options.WalletCredentials?.StorageCredentials
+                }
             };
             connection.SetTag("InboxId", inboxId);
 

--- a/src/Hyperledger.Aries/Storage/Models/WalletStorageConfiguration.cs
+++ b/src/Hyperledger.Aries/Storage/Models/WalletStorageConfiguration.cs
@@ -16,10 +16,26 @@ namespace Hyperledger.Aries.Storage
             [JsonProperty("path")]
             public string Path { get; set; }
 
+            /// <summary>
+            /// Gets or sets the database host url.
+            /// </summary>
+            /// <value>The url.</value>
+            [JsonProperty("url")]
+            public string Url { get; set; }
+
+            /// <summary>
+            /// Gets or sets the database wallet scheme.
+            /// </summary>
+            /// <value>The wallet scheme.</value>
+            [JsonProperty("wallet_scheme")]
+            public string WalletScheme { get; set; }
+
             /// <inheritdoc />
             public override string ToString() =>
                 $"{GetType().Name}: " +
-                $"Path={Path}";
+                $"Path={Path}" +
+                $"Url={Url}" +
+                $"WalletScheme={WalletScheme}";
         }
     }
 }

--- a/src/Hyperledger.Aries/Storage/Models/WalletStorageConfiguration.cs
+++ b/src/Hyperledger.Aries/Storage/Models/WalletStorageConfiguration.cs
@@ -70,6 +70,7 @@ namespace Hyperledger.Aries.Storage
                 $"{GetType().Name}: " +
                 $"Path={Path}" +
                 $"Url={Url}" +
+				$"Tls={Tls}" +
                 $"WalletScheme={WalletScheme}" +
 				$"DatabaseName={DatabaseName}" +
 				$"MaxConnections={MaxConnections}" +

--- a/src/Hyperledger.Aries/Storage/Models/WalletStorageConfiguration.cs
+++ b/src/Hyperledger.Aries/Storage/Models/WalletStorageConfiguration.cs
@@ -30,12 +30,51 @@ namespace Hyperledger.Aries.Storage
             [JsonProperty("wallet_scheme")]
             public string WalletScheme { get; set; }
 
+            /// <summary>
+            /// Gets or sets the database name.
+            /// </summary>
+            /// <value>The database name.</value>
+            [JsonProperty("database_name")]
+            public string DatabaseName { get; set; }
+
+            /// <summary>
+            /// Gets or sets the tls.
+            /// </summary>
+            /// <value>tls (on|off).</value>
+            [JsonProperty("tls")]
+            public string Tls { get; set; } = "off";
+
+            /// <summary>
+            /// Gets or sets max connections.
+            /// </summary>
+            /// <value>The max connections.</value>
+            [JsonProperty("max_connections")]
+            public int MaxConnections { get; set; } = 5;
+
+            /// <summary>
+            /// Gets or sets minimum idle count.
+            /// </summary>
+            /// <value>The minimum idle count.</value>
+            [JsonProperty("min_idle_count")]
+            public int MinIdleCount { get; set; } = 0;
+
+            /// <summary>
+            /// Gets or sets connection timeout.
+            /// </summary>
+            /// <value>The conncection timeout.</value>
+            [JsonProperty("connection_timeout")]
+            public int ConnectionTimeout { get; set; } = 5;
+
             /// <inheritdoc />
             public override string ToString() =>
                 $"{GetType().Name}: " +
                 $"Path={Path}" +
                 $"Url={Url}" +
-                $"WalletScheme={WalletScheme}";
+                $"WalletScheme={WalletScheme}" +
+				$"DatabaseName={DatabaseName}" +
+				$"MaxConnections={MaxConnections}" +
+				$"MinIdleCount={MinIdleCount}" +
+				$"ConnectionTimeout={ConnectionTimeout}";
         }
     }
 }

--- a/src/Hyperledger.Aries/Storage/Models/WalletStorageConfiguration.cs
+++ b/src/Hyperledger.Aries/Storage/Models/WalletStorageConfiguration.cs
@@ -49,21 +49,21 @@ namespace Hyperledger.Aries.Storage
             /// </summary>
             /// <value>The max connections.</value>
             [JsonProperty("max_connections")]
-            public int MaxConnections { get; set; } = 5;
+            public int? MaxConnections { get; set; }
 
             /// <summary>
             /// Gets or sets minimum idle count.
             /// </summary>
             /// <value>The minimum idle count.</value>
             [JsonProperty("min_idle_count")]
-            public int MinIdleCount { get; set; } = 0;
+            public int? MinIdleCount { get; set; }
 
             /// <summary>
             /// Gets or sets connection timeout.
             /// </summary>
             /// <value>The conncection timeout.</value>
             [JsonProperty("connection_timeout")]
-            public int ConnectionTimeout { get; set; } = 5;
+            public int? ConnectionTimeout { get; set; }
 
             /// <inheritdoc />
             public override string ToString() =>

--- a/test/Hyperledger.Aries.Tests/Storage/Models/WalletStorageConfigurationTest.cs
+++ b/test/Hyperledger.Aries.Tests/Storage/Models/WalletStorageConfigurationTest.cs
@@ -9,29 +9,61 @@ namespace Hyperledger.Aries.Tests.Storage.Models
         private const string Path = "Path";
         private const string Url = "Url";
         private const string WalletScheme = "WalletScheme";
+        private const string DatabaseName = "DatabaseName";
+        private const string Tls = "on";
+        private const int MaxConnections = 10;
+        private const int MinIdleCount = 10;
+        private const int ConnectionTimeout = 10;
 
         [Fact(DisplayName = "Wallet configuration model should correctly set and stringify all parameters")]
         public void WalletStorageConfigurationModel()
         {
-            WalletConfiguration.WalletStorageConfiguration walletStorageConfiguration = new WalletConfiguration.WalletStorageConfiguration()
+            WalletConfiguration.WalletStorageConfiguration walletStorageConfiguration = new WalletConfiguration.WalletStorageConfiguration
             {
                 Path = Path,
                 Url = Url,
-                WalletScheme = WalletScheme
+                WalletScheme = WalletScheme,
+                DatabaseName = DatabaseName,
+                Tls = Tls,
+                MaxConnections = MaxConnections,
+                MinIdleCount = MinIdleCount,
+                ConnectionTimeout = ConnectionTimeout
             };
 
-            walletStorageConfiguration.Path.Should().Be(Path);
-            walletStorageConfiguration.Url.Should().Be(Url);
-            walletStorageConfiguration.WalletScheme.Should().Be(WalletScheme);
+            walletStorageConfiguration.Should().BeEquivalentTo(new
+            {
+                Path,
+                Url,
+                WalletScheme,
+                DatabaseName,
+                Tls,
+                MaxConnections,
+                MinIdleCount,
+                ConnectionTimeout
+            });
             walletStorageConfiguration.ToString().Should().Be(
                 "WalletStorageConfiguration: " +
                 $"Path={Path}" +
                 $"Url={Url}" +
+                $"Tls={Tls}" +
                 $"WalletScheme={WalletScheme}" +
                 $"DatabaseName={DatabaseName}" +
                 $"MaxConnections={MaxConnections}" +
                 $"MinIdleCount={MinIdleCount}" +
-                $"ConnectionTimeout={ConnectionTimeout}";);
+                $"ConnectionTimeout={ConnectionTimeout}");
+        }
+
+        [Fact(DisplayName = "Wallet configuration model should use default parameters if they are not specified")]
+        public void WalletStorageConfigurationModelDefaults()
+        {
+            WalletConfiguration.WalletStorageConfiguration walletStorageConfiguration = new WalletConfiguration.WalletStorageConfiguration();
+
+            walletStorageConfiguration.Should().BeEquivalentTo(new
+            {
+                MaxConnections = 5,
+                MinIdleCount = 0,
+                ConnectionTimeout = 5
+            });
         }
     }
 }

--- a/test/Hyperledger.Aries.Tests/Storage/Models/WalletStorageConfigurationTest.cs
+++ b/test/Hyperledger.Aries.Tests/Storage/Models/WalletStorageConfigurationTest.cs
@@ -53,7 +53,7 @@ namespace Hyperledger.Aries.Tests.Storage.Models
                 $"ConnectionTimeout={ConnectionTimeout}");
         }
 
-        [Fact(DisplayName = "Wallet configuration model should use default parameters if they are not specified")]
+        [Fact(DisplayName = "Wallet configuration model should use default values if they are not specified")]
         public void WalletStorageConfigurationModelDefaults()
         {
             WalletConfiguration.WalletStorageConfiguration walletStorageConfiguration = new WalletConfiguration.WalletStorageConfiguration();

--- a/test/Hyperledger.Aries.Tests/Storage/Models/WalletStorageConfigurationTest.cs
+++ b/test/Hyperledger.Aries.Tests/Storage/Models/WalletStorageConfigurationTest.cs
@@ -60,6 +60,7 @@ namespace Hyperledger.Aries.Tests.Storage.Models
 
             walletStorageConfiguration.Should().BeEquivalentTo(new
             {
+                Tls = "off",
                 MaxConnections = 5,
                 MinIdleCount = 0,
                 ConnectionTimeout = 5

--- a/test/Hyperledger.Aries.Tests/Storage/Models/WalletStorageConfigurationTest.cs
+++ b/test/Hyperledger.Aries.Tests/Storage/Models/WalletStorageConfigurationTest.cs
@@ -52,19 +52,5 @@ namespace Hyperledger.Aries.Tests.Storage.Models
                 $"MinIdleCount={MinIdleCount}" +
                 $"ConnectionTimeout={ConnectionTimeout}");
         }
-
-        [Fact(DisplayName = "Wallet configuration model should use default values if they are not specified")]
-        public void WalletStorageConfigurationModelDefaults()
-        {
-            WalletConfiguration.WalletStorageConfiguration walletStorageConfiguration = new WalletConfiguration.WalletStorageConfiguration();
-
-            walletStorageConfiguration.Should().BeEquivalentTo(new
-            {
-                Tls = "off",
-                MaxConnections = 5,
-                MinIdleCount = 0,
-                ConnectionTimeout = 5
-            });
-        }
     }
 }

--- a/test/Hyperledger.Aries.Tests/Storage/Models/WalletStorageConfigurationTest.cs
+++ b/test/Hyperledger.Aries.Tests/Storage/Models/WalletStorageConfigurationTest.cs
@@ -1,0 +1,34 @@
+using FluentAssertions;
+using Hyperledger.Aries.Storage;
+using Xunit;
+
+namespace Hyperledger.Aries.Tests.Storage.Models
+{
+    public class WalletStorageConfigurationTest
+    {
+        private const string Path = "Path";
+        private const string Url = "Url";
+        private const string WalletScheme = "WalletScheme";
+
+        [Fact(DisplayName = "Wallet configuration model should correctly set and stringify all parameters")]
+        public void WalletStorageConfigurationModel()
+        {
+            WalletConfiguration.WalletStorageConfiguration walletStorageConfiguration = new WalletConfiguration.WalletStorageConfiguration()
+            {
+                Path = Path,
+                Url = Url,
+                WalletScheme = WalletScheme
+            };
+
+            walletStorageConfiguration.Path.Should().Be(Path);
+            walletStorageConfiguration.Url.Should().Be(Url);
+            walletStorageConfiguration.WalletScheme.Should().Be(WalletScheme);
+            walletStorageConfiguration.ToString().Should().Be(
+                "WalletStorageConfiguration: " +
+                $"Path={Path}" +
+                $"Path={Path}" +
+                $"Url={Url}" +
+                $"WalletScheme={WalletScheme}");
+        }
+    }
+}

--- a/test/Hyperledger.Aries.Tests/Storage/Models/WalletStorageConfigurationTest.cs
+++ b/test/Hyperledger.Aries.Tests/Storage/Models/WalletStorageConfigurationTest.cs
@@ -26,9 +26,12 @@ namespace Hyperledger.Aries.Tests.Storage.Models
             walletStorageConfiguration.ToString().Should().Be(
                 "WalletStorageConfiguration: " +
                 $"Path={Path}" +
-                $"Path={Path}" +
                 $"Url={Url}" +
-                $"WalletScheme={WalletScheme}");
+                $"WalletScheme={WalletScheme}" +
+                $"DatabaseName={DatabaseName}" +
+                $"MaxConnections={MaxConnections}" +
+                $"MinIdleCount={MinIdleCount}" +
+                $"ConnectionTimeout={ConnectionTimeout}";);
         }
     }
 }


### PR DESCRIPTION
#### Short description of what this resolves:

Add support for storing inbox records using the Postgres storage plugin on the Mediator agent.

#### Changes proposed in this pull request:

- Propagate storage credentials and storage configuration used for the storage plugins.
- Bump NuGet package version.
- Unit tests for the case when credentials and configuration options are set.
- Expand WalletStorageConfiguration so that values don't get removed inside recordService.AddAsync(agentContext.Wallet, inboxRecord) call.

**Fixes**: #
