### PR TITLE
Add support for RAW key derivation on inbox wallet create

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
         <Product>Hyperledger Aries Dotnet</Product>
         <RepositoryUrl>https://github.com/hyperledger/aries-framework-dotnet.git</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
-        <Version>1.5.5</Version>
+        <Version>1.5.6</Version>
     </PropertyGroup>
 
     <!-- Common compile parameters -->

--- a/src/Hyperledger.Aries.Routing.Mediator/Handlers/RoutingInboxHandler.cs
+++ b/src/Hyperledger.Aries.Routing.Mediator/Handlers/RoutingInboxHandler.cs
@@ -19,6 +19,7 @@ namespace Hyperledger.Aries.Routing
         private readonly IRoutingStore routingStore;
         private readonly AgentOptions options;
         private readonly ILogger<RoutingInboxHandler> logger;
+        private const string IndySdkDefaultOptions = "{}";
 
         public RoutingInboxHandler(
             IWalletRecordService recordService,
@@ -157,8 +158,8 @@ namespace Hyperledger.Aries.Routing
                 throw new InvalidOperationException("Can't create inbox if connection is not in final state");
             }
 
-            var inboxId = $"Edge{Guid.NewGuid().ToString("N")}";
-            var inboxKey = Guid.NewGuid().ToString();
+            string inboxId = $"Edge{Guid.NewGuid().ToString("N")}";
+            string inboxKey = await Wallet.GenerateWalletKeyAsync(IndySdkDefaultOptions);
 
             var inboxRecord = new InboxRecord
             {
@@ -172,6 +173,7 @@ namespace Hyperledger.Aries.Routing
                 WalletCredentials = new WalletCredentials
                 {
                     Key = inboxKey,
+                    KeyDerivationMethod = options.WalletCredentials?.KeyDerivationMethod,
                     StorageCredentials = options.WalletCredentials?.StorageCredentials
                 }
             };

--- a/test/Hyperledger.Aries.Tests/WalletTests.cs
+++ b/test/Hyperledger.Aries.Tests/WalletTests.cs
@@ -47,6 +47,26 @@ namespace Hyperledger.Aries.Tests
             Assert.True(wallet.IsOpen);
         }
 
+        [Fact(DisplayName = "Should create wallet with RAW key derivation")]
+        public async Task CanCreateWallet_WhenRawKeyDerivationIsUsed()
+        {
+            var config = new WalletConfiguration { Id = Guid.NewGuid().ToString() };
+            var creds = new WalletCredentials
+            {
+                Key = await Wallet.GenerateWalletKeyAsync("{}"),
+                KeyDerivationMethod = "RAW",
+            };
+
+            var walletService = new DefaultWalletService();
+
+            await walletService.CreateWalletAsync(config, creds);
+
+            var wallet = await walletService.GetWalletAsync(config, creds);
+
+            Assert.NotNull(wallet);
+            Assert.True(wallet.IsOpen);
+        }
+
         [Fact]
         public async Task CanCreateGetAndCloseWallet()
         {
@@ -107,7 +127,7 @@ namespace Hyperledger.Aries.Tests
 
             Assert.NotNull(wallet);
             Assert.True(wallet.IsOpen);
-            
+
             await walletService.DeleteWalletAsync(config, creds);
 
             await Assert.ThrowsAsync<WalletNotFoundException>(() => walletService.GetWalletAsync(config, creds));


### PR DESCRIPTION
#### Short description of what this resolves:

- The default mode to derive wallet key is via an algorithm argon2 which is very CPU and memory consuming. In order to minimize resource usage, we added support for RAW key derivation since safe storage of the wallet keys can be provided.

#### Changes proposed in this pull request:

- Add an ability to provide a custom key derivation method.
- Generate wallet key using secure generator provided in the indy-sdk. Generated wallet key is suitable for the "RAW" derivation method.
- Test that wallet with described parameters can be successfully created.

**Fixes**: #
