### PR TITLE
Optimize storage size, when saving credential record data

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
         <Product>Hyperledger Aries Dotnet</Product>
         <RepositoryUrl>https://github.com/hyperledger/aries-framework-dotnet.git</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
-        <Version>1.5.6</Version>
+        <Version>1.6.0</Version>
     </PropertyGroup>
 
     <!-- Common compile parameters -->

--- a/src/Hyperledger.Aries/Features/IssueCredential/DefaultCredentialService.cs
+++ b/src/Hyperledger.Aries/Features/IssueCredential/DefaultCredentialService.cs
@@ -419,7 +419,6 @@ namespace Hyperledger.Aries.Features.IssueCredential
 
             credentialRecord.CredentialId = credentialId;
             await credentialRecord.TriggerAsync(CredentialTrigger.Issue);
-
             await RecordService.UpdateAsync(agentContext.Wallet, credentialRecord);
             EventAggregator.Publish(new ServiceMessageProcessingEvent
             {
@@ -559,9 +558,6 @@ namespace Hyperledger.Aries.Features.IssueCredential
             credential.RequestJson = credentialAttachment.Data.Base64.GetBytesFromBase64().GetUTF8String();
             credential.ConnectionId = connection?.Id;
             await credential.TriggerAsync(CredentialTrigger.Request);
-
-            credential.RemoveTag("OfferData");
-
             await RecordService.UpdateAsync(agentContext.Wallet, credential);
             EventAggregator.Publish(new ServiceMessageProcessingEvent
             {

--- a/src/Hyperledger.Aries/Features/IssueCredential/DefaultCredentialService.cs
+++ b/src/Hyperledger.Aries/Features/IssueCredential/DefaultCredentialService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -419,6 +419,7 @@ namespace Hyperledger.Aries.Features.IssueCredential
 
             credentialRecord.CredentialId = credentialId;
             await credentialRecord.TriggerAsync(CredentialTrigger.Issue);
+
             await RecordService.UpdateAsync(agentContext.Wallet, credentialRecord);
             EventAggregator.Publish(new ServiceMessageProcessingEvent
             {
@@ -558,6 +559,9 @@ namespace Hyperledger.Aries.Features.IssueCredential
             credential.RequestJson = credentialAttachment.Data.Base64.GetBytesFromBase64().GetUTF8String();
             credential.ConnectionId = connection?.Id;
             await credential.TriggerAsync(CredentialTrigger.Request);
+
+            credential.RemoveTag("OfferData");
+
             await RecordService.UpdateAsync(agentContext.Wallet, credential);
             EventAggregator.Publish(new ServiceMessageProcessingEvent
             {

--- a/src/Hyperledger.Aries/Features/IssueCredential/Records/CredentialRecord.cs
+++ b/src/Hyperledger.Aries/Features/IssueCredential/Records/CredentialRecord.cs
@@ -46,6 +46,7 @@ namespace Hyperledger.Aries.Features.IssueCredential
         /// Gets or sets the definition identifier of this credential.
         /// </summary>
         /// <value>The credential definition identifier.</value>
+        [JsonIgnore]
         public string CredentialDefinitionId
         {
             get => Get();
@@ -56,10 +57,11 @@ namespace Hyperledger.Aries.Features.IssueCredential
         /// Gets or sets the credential request json.
         /// </summary>
         /// <value>The request json.</value>
+        [JsonIgnore]
         public string RequestJson
         {
-            get;
-            set;
+            get => Get();
+            set => Set(value);
         }
 
         /// <summary>
@@ -76,10 +78,11 @@ namespace Hyperledger.Aries.Features.IssueCredential
         /// Gets or sets the credential offer json.
         /// </summary>
         /// <value>The offer json.</value>
+        [JsonIgnore]
         public string OfferJson
         {
-            get;
-            set;
+            get => Get();
+            set => Set(value);
         }
 
         /// <summary>


### PR DESCRIPTION
This PR reduces the size of the Value column for the record persistence by moving large fields like OfferJson and RequestJson to tags. Tags are persisted in separate columns in the underlying storage.