### PR TITLE
delete unsupported msg types from mediator inbox

### DIFF
--- a/src/Hyperledger.Aries.Routing.Edge/EdgeClientService.cs
+++ b/src/Hyperledger.Aries.Routing.Edge/EdgeClientService.cs
@@ -50,7 +50,7 @@ namespace Hyperledger.Aries.Routing.Edge
             this.agentoptions = agentOptions.Value;
         }
 
-        public async Task AddRouteAsync(IAgentContext agentContext, string routeDestination)
+        public virtual async Task AddRouteAsync(IAgentContext agentContext, string routeDestination)
         {
             var connection = await GetMediatorConnectionAsync(agentContext);
             if (connection != null)
@@ -60,7 +60,7 @@ namespace Hyperledger.Aries.Routing.Edge
             }
         }
 
-        public async Task CreateInboxAsync(IAgentContext agentContext, Dictionary<string, string> metadata = null)
+        public virtual async Task CreateInboxAsync(IAgentContext agentContext, Dictionary<string, string> metadata = null)
         {
             var provisioning = await provisioningService.GetProvisioningAsync(agentContext.Wallet);
             if (provisioning.GetTag(MediatorInboxIdTagName) != null)
@@ -91,7 +91,7 @@ namespace Hyperledger.Aries.Routing.Edge
             return connection;
         }
 
-        public async Task<AgentPublicConfiguration> DiscoverConfigurationAsync(string agentEndpoint)
+        public virtual async Task<AgentPublicConfiguration> DiscoverConfigurationAsync(string agentEndpoint)
         {
             var httpClient = httpClientFactory.CreateClient();
             var response = await httpClient.GetAsync($"{agentEndpoint}/.well-known/agent-configuration").ConfigureAwait(false);
@@ -100,7 +100,7 @@ namespace Hyperledger.Aries.Routing.Edge
             return responseJson.ToObject<AgentPublicConfiguration>();
         }
 
-        public async Task<(int, IEnumerable<InboxItemMessage>)> FetchInboxAsync(IAgentContext agentContext)
+        public virtual async Task<(int, IEnumerable<InboxItemMessage>)> FetchInboxAsync(IAgentContext agentContext)
         {
             var connection = await GetMediatorConnectionAsync(agentContext);
             if (connection == null)
@@ -120,6 +120,10 @@ namespace Hyperledger.Aries.Routing.Edge
                     await agentContext.Agent.ProcessAsync(agentContext, new PackedMessageContext(item.Data));
                     processedItems.Add(item.Id);
                 }
+                catch (AriesFrameworkException e) when (e.ErrorCode == ErrorCode.InvalidMessage) 
+                {
+                    processedItems.Add(item.Id);
+                }
                 catch (Exception)
                 {
                     unprocessedItem.Add(item);
@@ -134,7 +138,7 @@ namespace Hyperledger.Aries.Routing.Edge
             return (processedItems.Count, unprocessedItem);
         }
 
-        public async Task AddDeviceAsync(IAgentContext agentContext, AddDeviceInfoMessage message)
+        public virtual async Task AddDeviceAsync(IAgentContext agentContext, AddDeviceInfoMessage message)
         {
             var connection = await GetMediatorConnectionAsync(agentContext);
             if (connection != null)


### PR DESCRIPTION
Signed-off-by: Sebastian Bickerle <sebastian.bickerle@main-incubator.com>

#### Short description of what this resolves:
Inbox messages stored at the mediator which are not supported by message handlers of the edge client remain as unprocessed messages in the inbox. Therefore, those messages are processed over and over again each time the client fetches the inbox. In oder to prevent a bloated inbox, I propose to remove those messages from the inbox. 

#### Changes proposed in this pull request:

- Catch exception thrown by unsupported message types and mark message for deletion
- Declare methods in EdgeClientService as virtual to allow overwrites of the default behaviour
