### PR TITLE
Allow switching between return routing types

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
         <Product>Hyperledger Aries Dotnet</Product>
         <RepositoryUrl>https://github.com/hyperledger/aries-framework-dotnet.git</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
-        <Version>1.6.2</Version>
+        <Version>1.6.3</Version>
     </PropertyGroup>
 
     <!-- Common compile parameters -->

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,6 +20,11 @@ jobs:
       buildConfiguration: "Release"
 
     steps:
+      - task: UseDotNet@2
+        displayName: 'Install sdk version'
+        inputs:
+          packageType: 'sdk'
+          version: '3.1.301'
 
       - task: DotNetCoreCLI@2
         inputs:

--- a/src/Hyperledger.Aries/Agents/Transport/DefaultMessageService.cs
+++ b/src/Hyperledger.Aries/Agents/Transport/DefaultMessageService.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Hyperledger.Aries.Decorators.Transport;
 using Hyperledger.Aries.Utils;
 using Hyperledger.Indy.WalletApi;
 using Microsoft.Extensions.Logging;
@@ -79,7 +80,7 @@ namespace Hyperledger.Aries.Agents
 
         /// <inheritdoc />
         public async Task<MessageContext> SendReceiveAsync(IAgentContext agentContext, AgentMessage message, string recipientKey,
-            string endpointUri, string[] routingKeys = null, string senderKey = null)
+            string endpointUri, string[] routingKeys = null, string senderKey = null, ReturnRouteTypes returnType = ReturnRouteTypes.all)
         {
             Logger.LogInformation(LoggingEvents.SendMessage, "Recipient {0} Endpoint {1}", recipientKey,
                 endpointUri);
@@ -100,7 +101,7 @@ namespace Hyperledger.Aries.Agents
             if (dispatcher == null)
                 throw new AriesFrameworkException(ErrorCode.A2AMessageTransmissionError, $"No registered dispatcher for transport scheme : {uri.Scheme}");
 
-            message.AddReturnRouting();
+            message.AddReturnRouting(returnType);
             var wireMsg = await CryptoUtils.PrepareAsync(agentContext, message, recipientKey, routingKeys, senderKey);
 
             var response = await dispatcher.DispatchAsync(uri, new PackedMessageContext(wireMsg));

--- a/src/Hyperledger.Aries/Agents/Transport/IMessageService.cs
+++ b/src/Hyperledger.Aries/Agents/Transport/IMessageService.cs
@@ -1,5 +1,5 @@
 ﻿using System.Threading.Tasks;
-using Hyperledger.Indy.WalletApi;
+using Hyperledger.Aries.Decorators.Transport;
 
 namespace Hyperledger.Aries.Agents
 {
@@ -25,15 +25,16 @@ namespace Hyperledger.Aries.Agents
         /// Sends the message and receives a response by adding return routing decorator
         /// according to the Routing RFC.
         /// </summary>
-        /// <param name="agentContext"></param>
-        /// <param name="message"></param>
-        /// <param name="recipientKey"></param>
-        /// <param name="endpointUri"></param>
-        /// <param name="routingKeys"></param>
-        /// <param name="senderKey"></param>
+        /// <param name="agentContext">The agentContext.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="recipientKey">The recipients key.</param>
+        /// <param name="endpointUri">The destination endpoint.</param>
+        /// <param name="routingKeys">The routing keys.</param>
+        /// <param name="senderKey">The senders key.</param>
+        /// <param name="returnType">The type of return routing.</param>
         /// <returns></returns>
         Task<MessageContext> SendReceiveAsync(IAgentContext agentContext, AgentMessage message, string recipientKey,
-            string endpointUri, string[] routingKeys = null, string senderKey = null);
+            string endpointUri, string[] routingKeys = null, string senderKey = null, ReturnRouteTypes returnType = ReturnRouteTypes.all);
 
     }
 }

--- a/src/Hyperledger.Aries/Decorators/Transport/TransportDecoratorExtensions.cs
+++ b/src/Hyperledger.Aries/Decorators/Transport/TransportDecoratorExtensions.cs
@@ -13,11 +13,12 @@ namespace System
         /// Adds return routing to message
         /// </summary>
         /// <param name="message">The message to add return routing</param>
-        public static void AddReturnRouting(this AgentMessage message)
+        /// <param name="returnType">The message to add return routing</param>
+        public static void AddReturnRouting(this AgentMessage message, ReturnRouteTypes returnType = ReturnRouteTypes.all)
         {
             message.AddDecorator(new TransportDecorator
             {
-                ReturnRoute = ReturnRouteTypes.all.ToString("G")
+                ReturnRoute = returnType.ToString("G")
             }, DecoratorNames.TransportDecorator);
         }
 


### PR DESCRIPTION
#### Short description of what this resolves:
This PR enables implementers to select different types of return routing. Before, the `return_routing` decorator was always set to `all` and could not be changed. Now, the default value is still `all`, but the value can be defined via a parameter of `SendReceiveAsync`.

#### Changes proposed in this pull request:

- Add parameter to `SendReceiveAsync` in `IMessageService.cs` and `DefaultMessageService.cs` which specifies the desired return_routing type
