### PR TITLE
Change references to streetcred-id GitHub org to trinsic-id

### DIFF
--- a/docs/docker.rst
+++ b/docs/docker.rst
@@ -14,7 +14,7 @@ Usage
     FROM streetcred/dotnet-indy:latest
 
 The images are based on `ubuntu:16.04`. You can check `the docker repo
-<https://github.com/streetcred-id/docker>`_ if you want to build your own image or require specific version of .NET Core or libindy.
+<https://github.com/trinsic-id/docker>`_ if you want to build your own image or require specific version of .NET Core or libindy.
 
 Example build
 =============

--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -203,8 +203,8 @@ Finally, to get this program to run we will need to add a couple of utility file
 
 First, add a Utils folder. Add these two files to the Utils folder (Open these links in new tabs): 
 
-`NameGenerator.cs <https://raw.githubusercontent.com/streetcred-id/agent-framework/master/samples/aspnetcore/Utils/NameGenerator.cs>`_
-`Extensions.cs <https://raw.githubusercontent.com/streetcred-id/agent-framework/master/samples/aspnetcore/Utils/Extensions.cs>`_
+`NameGenerator.cs <https://raw.githubusercontent.com/trinsic-id/agent-framework/master/samples/aspnetcore/Utils/NameGenerator.cs>`_
+`Extensions.cs <https://raw.githubusercontent.com/trinsic-id/agent-framework/master/samples/aspnetcore/Utils/Extensions.cs>`_
 
 
 --------------


### PR DESCRIPTION
Signed-off-by: Stephen Curran <swcurran@gmail.com>

#### Short description of what this resolves:
There are some references in the repo to the old "streetcred-id" GitHub organization that need to be changed to "trinsic-id".  Another party has grabbed the "streetcred-id" github account and is using it, so the links are no longer reliable.

#### Changes proposed in this pull request:

- Rename several paths into GitHub to use Trinsic

**Fixes**: #
