### PR TITLE
did:key Transformation

### DIFF
--- a/src/Hyperledger.Aries.TestHarness/AgentScenarios.cs
+++ b/src/Hyperledger.Aries.TestHarness/AgentScenarios.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Reactive.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Hyperledger.Aries;
 using Hyperledger.Aries.Agents;
 using Hyperledger.Aries.Configuration;
 using Hyperledger.Aries.Contracts;
@@ -24,7 +23,7 @@ namespace Hyperledger.TestHarness
 {
     public static class AgentScenarios
     {
-        public static async Task<(ConnectionRecord inviteeConnection,ConnectionRecord inviterConnection)> EstablishConnectionAsync(MockAgent invitee, MockAgent inviter)
+        public static async Task<(ConnectionRecord inviteeConnection,ConnectionRecord inviterConnection)> EstablishConnectionAsync(MockAgent invitee, MockAgent inviter, bool useDidKeyFormat = false)
         {
             var slim = new SemaphoreSlim(0, 1);
             
@@ -37,7 +36,7 @@ namespace Hyperledger.TestHarness
                 .Subscribe(x => slim.Release());
 
             (var invitation, var inviterConnection) = await connectionService.CreateInvitationAsync(invitee.Context,
-                new InviteConfiguration { AutoAcceptConnection = true });
+                new InviteConfiguration { AutoAcceptConnection = true, UseDidKeyFormat = useDidKeyFormat});
 
             (var request, var inviteeConnection) =
                 await connectionService.CreateRequestAsync(inviter.Context, invitation);
@@ -61,7 +60,7 @@ namespace Hyperledger.TestHarness
             return (connectionRecord1, connectionRecord2);
         }
 
-        public static async Task<(ConnectionRecord inviteeConnection, ConnectionRecord inviterConnection)> EstablishConnectionWithReturnRoutingAsync(MockAgent invitee, MockAgent inviter)
+        public static async Task<(ConnectionRecord inviteeConnection, ConnectionRecord inviterConnection)> EstablishConnectionWithReturnRoutingAsync(MockAgent invitee, MockAgent inviter, bool useDidKeyFormat = false)
         {
             var slim = new SemaphoreSlim(0, 1);
 
@@ -74,7 +73,7 @@ namespace Hyperledger.TestHarness
                 .Subscribe(x => slim.Release());
 
             (var invitation, var inviterConnection) = await connectionService.CreateInvitationAsync(invitee.Context,
-                new InviteConfiguration { AutoAcceptConnection = true });
+                new InviteConfiguration { AutoAcceptConnection = true, UseDidKeyFormat = useDidKeyFormat});
 
             (var request, var inviteeConnection) =
                 await connectionService.CreateRequestAsync(inviter.Context, invitation);

--- a/src/Hyperledger.Aries.TestHarness/AgentScenarios.cs
+++ b/src/Hyperledger.Aries.TestHarness/AgentScenarios.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Hyperledger.Aries.Agents;
 using Hyperledger.Aries.Configuration;
 using Hyperledger.Aries.Contracts;
+using Hyperledger.Aries.Extensions;
 using Hyperledger.Aries.Features.BasicMessage;
 using Hyperledger.Aries.Features.DidExchange;
 using Hyperledger.Aries.Features.Discovery;
@@ -174,6 +175,43 @@ namespace Hyperledger.TestHarness
                 issuerCredRecord.GetTag(TagConstants.LastThreadId),
                 holderCredRecord.GetTag(TagConstants.LastThreadId));
         }
+        
+        public static async Task IssueCredentialConnectionlessAsync(MockAgent issuer, MockAgent holder, List<CredentialPreviewAttribute> credentialAttributes, bool useDidKeyFormat)
+        {
+            var credentialService = issuer.GetService<ICredentialService>();
+            var schemaService = issuer.GetService<ISchemaService>();
+            var provisionService = issuer.GetService<IProvisioningService>();
+
+            var issuerProv = await provisionService.GetProvisioningAsync(issuer.Context.Wallet);
+
+            var (definitionId, _) = await Scenarios.CreateDummySchemaAndNonRevokableCredDef(issuer.Context, schemaService,
+                issuerProv.IssuerDid, credentialAttributes.Select(_ => _.Name).ToArray());
+
+            (var offer, var issuerCredentialRecord) = await credentialService.CreateOfferAsync(
+                agentContext: issuer.Context,
+                config: new OfferConfiguration
+                {
+                    IssuerDid = issuerProv.IssuerDid,
+                    CredentialDefinitionId = definitionId,
+                    CredentialAttributeValues = credentialAttributes,
+                    UseDidKeyFormat = useDidKeyFormat
+                });
+
+            var holderCredentialRecord = await credentialService.CreateCredentialAsync(holder.Context, offer);
+
+            Assert.NotNull(holderCredentialRecord.CredentialAttributesValues);
+            Assert.True(holderCredentialRecord.CredentialAttributesValues.Count() == 2);
+            
+            var issuerCredRecord = await credentialService.GetAsync(issuer.Context, issuerCredentialRecord.Id);
+            var holderCredRecord = await credentialService.GetAsync(holder.Context, holderCredentialRecord.Id);
+
+            Assert.Equal(CredentialState.Issued, issuerCredRecord.State);
+            Assert.Equal(CredentialState.Issued, holderCredRecord.State);
+
+            Assert.Equal(
+                issuerCredRecord.GetTag(TagConstants.LastThreadId),
+                holderCredRecord.GetTag(TagConstants.LastThreadId));
+        }
 
         public static async Task ProofProtocolAsync(MockAgent requestor, MockAgent holder,
             ConnectionRecord requestorConnection, ConnectionRecord holderConnection, ProofRequest proofRequest)
@@ -214,6 +252,35 @@ namespace Hyperledger.TestHarness
             await messageService.SendAsync(holder.Context, proofMsg, holderConnection);
 
             await proofSlim.WaitAsync(TimeSpan.FromSeconds(30));
+
+            var requestorProofRecord = await proofService.GetAsync(requestor.Context, requestorRecord.Id);
+            var holderProofRecord = await proofService.GetAsync(holder.Context, holderRecord.Id);
+
+            Assert.True(requestorProofRecord.State == ProofState.Accepted);
+            Assert.True(holderProofRecord.State == ProofState.Accepted);
+
+            var isProofValid = await proofService.VerifyProofAsync(requestor.Context, requestorProofRecord.Id);
+
+            Assert.True(isProofValid);
+        }
+        
+        public static async Task ProofProtocolConnectionlessAsync(MockAgent requestor, MockAgent holder, ProofRequest proofRequest, bool useDidKeyFormat)
+        {
+            var proofService = requestor.GetService<IProofService>();
+
+            var (requestMsg, requestorRecord) = await proofService.CreateRequestAsync(requestor.Context, proofRequest, useDidKeyFormat: useDidKeyFormat);
+
+            var requestAttachment = requestMsg.Requests.FirstOrDefault(x => x.Id == "libindy-request-presentation-0")
+                                    ?? throw new ArgumentException("Presentation request attachment not found.");
+            
+            var requestJson = requestAttachment.Data.Base64.GetBytesFromBase64().GetUTF8String();
+            var request = JsonConvert.DeserializeObject<ProofRequest>(requestJson);
+
+            var requestedCredentials =
+                await ProofServiceUtils.GetAutoRequestedCredentialsForProofCredentials(holder.Context, proofService,
+                    request);
+
+            var holderRecord = await proofService.CreatePresentationAsync(holder.Context, requestMsg, requestedCredentials);
 
             var requestorProofRecord = await proofService.GetAsync(requestor.Context, requestorRecord.Id);
             var holderProofRecord = await proofService.GetAsync(holder.Context, holderRecord.Id);

--- a/src/Hyperledger.Aries.TestHarness/Scenarios.cs
+++ b/src/Hyperledger.Aries.TestHarness/Scenarios.cs
@@ -3,17 +3,17 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Hyperledger.Aries.Agents;
 using Hyperledger.Aries.Extensions;
-using Hyperledger.TestHarness.Utils;
+using Hyperledger.Aries.Features.DidExchange;
+using Hyperledger.Aries.Features.IssueCredential;
+using Hyperledger.Aries.Features.PresentProof;
 using Hyperledger.Indy.AnonCredsApi;
 using Hyperledger.Indy.DidApi;
 using Hyperledger.Indy.PoolApi;
+using Hyperledger.TestHarness.Utils;
 using Newtonsoft.Json;
 using Xunit;
-using Hyperledger.Aries.Features.DidExchange;
-using Hyperledger.Aries.Agents;
-using Hyperledger.Aries.Features.IssueCredential;
-using Hyperledger.Aries.Features.PresentProof;
 
 namespace Hyperledger.TestHarness
 {
@@ -25,7 +25,8 @@ namespace Hyperledger.TestHarness
             IAgentContext firstContext,
             IAgentContext secondContext,
             ConnectionInvitationMessage inviteMessage = null,
-            string inviteeconnectionId = null)
+            string inviteeconnectionId = null,
+            bool useDidKeyFormat = false)
         {
             // Create invitation by the issuer
             var connectionSecondId = Guid.NewGuid().ToString();
@@ -42,7 +43,8 @@ namespace Hyperledger.TestHarness
                 {
                     Name = "Holder",
                     ImageUrl = "www.holderdomain.com/profilephoto"
-                }
+                },
+                UseDidKeyFormat = useDidKeyFormat
             };
 
             if (inviteMessage == null)

--- a/src/Hyperledger.Aries.TestHarness/TestConstants.cs
+++ b/src/Hyperledger.Aries.TestHarness/TestConstants.cs
@@ -6,7 +6,7 @@
 
         public const string DefaultMasterSecret = "DefaultMasterSecret";
 
-        public const string DefaultVerkey = "~KQ5aMFDb5cmqkv3E98ctUg";
+        public const string DefaultVerkey = "MeHaPyPGsbBCgMKo13oWK7MeHaPyPGsbBCgMKo13oWK7";
 
         public const string StewartDid = "000000000000000000000000Steward1";
     }

--- a/src/Hyperledger.Aries/Decorators/Service/ServiceDecoratorExtensions.cs
+++ b/src/Hyperledger.Aries/Decorators/Service/ServiceDecoratorExtensions.cs
@@ -1,5 +1,7 @@
+using System.Linq;
 using Hyperledger.Aries.Configuration;
 using Hyperledger.Aries.Decorators.Service;
+using Hyperledger.Aries.Utils;
 
 namespace System
 {
@@ -12,14 +14,15 @@ namespace System
         /// Get a service decorator representation for this provisioning record
         /// </summary>
         /// <param name="record"></param>
+        /// <param name="useDidKeyFormat"></param>
         /// <returns></returns>
-        public static ServiceDecorator ToServiceDecorator(this ProvisioningRecord record)
+        public static ServiceDecorator ToServiceDecorator(this ProvisioningRecord record, bool useDidKeyFormat = false)
         {
             return new ServiceDecorator
             {
                 ServiceEndpoint = record.Endpoint.Uri,
-                RoutingKeys = record.Endpoint.Verkey,
-                RecipientKeys = new [] { record.IssuerVerkey }
+                RoutingKeys = useDidKeyFormat ? record.Endpoint.Verkey.Select(DidUtils.ConvertVerkeyToDidKey) : record.Endpoint.Verkey,
+                RecipientKeys = new [] { useDidKeyFormat ? DidUtils.ConvertVerkeyToDidKey(record.IssuerVerkey) : record.IssuerVerkey }
             };
         }
     }

--- a/src/Hyperledger.Aries/Features/DidExchange/DefaultConnectionService.cs
+++ b/src/Hyperledger.Aries/Features/DidExchange/DefaultConnectionService.cs
@@ -166,7 +166,7 @@ namespace Hyperledger.Aries.Features.DidExchange
                 Connection = new Connection
                 {
                     Did = connection.MyDid,
-                    DidDoc = connection.MyDidDoc(provisioning, useDidKeyFormat: useDidKeyFormat)
+                    DidDoc = connection.MyDidDoc(provisioning)
                 },
                 Label = provisioning.Owner?.Name,
                 ImageUrl = provisioning.Owner?.ImageUrl

--- a/src/Hyperledger.Aries/Features/DidExchange/Extensions/DidDocExtensions.cs
+++ b/src/Hyperledger.Aries/Features/DidExchange/Extensions/DidDocExtensions.cs
@@ -12,7 +12,7 @@ namespace Hyperledger.Aries.Features.DidExchange
         /// Default key type.
         /// </summary>
         public const string DefaultKeyType = "Ed25519VerificationKey2018";
-        
+
         /// <summary>
         /// Constructs my DID doc in a pairwise relationship from a connection record and the agents provisioning record.
         /// </summary>

--- a/src/Hyperledger.Aries/Features/DidExchange/Models/InviteConfiguration.cs
+++ b/src/Hyperledger.Aries/Features/DidExchange/Models/InviteConfiguration.cs
@@ -38,6 +38,11 @@ namespace Hyperledger.Aries.Features.DidExchange
         public bool AutoAcceptConnection { get; set; }
 
         /// <summary>
+        /// Indicator if this invitation/connection record should use the did:key exchange format
+        /// </summary>
+        public bool UseDidKeyFormat { get; set; } = false;
+
+        /// <summary>
         /// Controls the tags that are persisted against the invite/connection record.
         /// </summary>
         public Dictionary<string, string> Tags { get; set; } = new Dictionary<string, string>();

--- a/src/Hyperledger.Aries/Features/IssueCredential/DefaultCredentialService.cs
+++ b/src/Hyperledger.Aries/Features/IssueCredential/DefaultCredentialService.cs
@@ -530,7 +530,7 @@ namespace Hyperledger.Aries.Features.IssueCredential
 
             var (message, record) = await CreateOfferAsync(agentContext, config, null);
             var provisioning = await ProvisioningService.GetProvisioningAsync(agentContext.Wallet);
-            message.AddDecorator(provisioning.ToServiceDecorator(), DecoratorNames.ServiceDecorator);
+            message.AddDecorator(provisioning.ToServiceDecorator(config.UseDidKeyFormat), DecoratorNames.ServiceDecorator);
 
             await RecordService.UpdateAsync(agentContext.Wallet, record);
             return (message, record);

--- a/src/Hyperledger.Aries/Features/IssueCredential/Models/OfferConfiguration.cs
+++ b/src/Hyperledger.Aries/Features/IssueCredential/Models/OfferConfiguration.cs
@@ -29,5 +29,10 @@ namespace Hyperledger.Aries.Features.IssueCredential
         /// Controls the tags that are persisted against the offer record.
         /// </summary>
         public Dictionary<string, string> Tags { get; set; }
+
+        /// <summary>
+        /// Indicates if a connectionless offer should use did:key format
+        /// </summary>
+        public bool UseDidKeyFormat { get; set; } = false;
     }
 }

--- a/src/Hyperledger.Aries/Features/PresentProof/DefaultProofService.cs
+++ b/src/Hyperledger.Aries/Features/PresentProof/DefaultProofService.cs
@@ -578,14 +578,14 @@ namespace Hyperledger.Aries.Features.PresentProof
             message.ThreadFrom(threadId);
             return (message, proofRecord);
         }
-
+        
         /// <inheritdoc />
-        public virtual async Task<(RequestPresentationMessage, ProofRecord)> CreateRequestAsync(IAgentContext agentContext, ProofRequest proofRequest)
+        public virtual async Task<(RequestPresentationMessage, ProofRecord)> CreateRequestAsync(IAgentContext agentContext, ProofRequest proofRequest, bool useDidKeyFormat = false)
         {
             var (message, record) = await CreateRequestAsync(agentContext, proofRequest, null);
             var provisioning = await ProvisioningService.GetProvisioningAsync(agentContext.Wallet);
 
-            message.AddDecorator(provisioning.ToServiceDecorator(), DecoratorNames.ServiceDecorator);
+            message.AddDecorator(provisioning.ToServiceDecorator(useDidKeyFormat), DecoratorNames.ServiceDecorator);
             record.SetTag("RequestData", message.ToByteArray().ToBase64UrlString());
 
             return (message, record);

--- a/src/Hyperledger.Aries/Features/PresentProof/IProofService.cs
+++ b/src/Hyperledger.Aries/Features/PresentProof/IProofService.cs
@@ -66,8 +66,9 @@ namespace Hyperledger.Aries.Features.PresentProof
         /// </summary>
         /// <param name="agentContext"></param>
         /// <param name="proofRequest"></param>
+        /// <param name="useDidKeyFormat"></param>
         /// <returns></returns>
-        Task<(RequestPresentationMessage, ProofRecord)> CreateRequestAsync(IAgentContext agentContext, ProofRequest proofRequest);
+        Task<(RequestPresentationMessage, ProofRecord)> CreateRequestAsync(IAgentContext agentContext, ProofRequest proofRequest, bool useDidKeyFormat = false);
 
         /// <summary>
         /// Creates a proof request.

--- a/src/Hyperledger.Aries/Utils/CryptoUtils.cs
+++ b/src/Hyperledger.Aries/Utils/CryptoUtils.cs
@@ -118,6 +118,11 @@ namespace Hyperledger.Aries.Utils
         {
             if (message == null) throw new ArgumentNullException(nameof(message));
             if (recipientKey == null) throw new ArgumentNullException(nameof(recipientKey));
+            
+            // Bookmark: Transform recipientKey and routingKeys in did:key format into verkeys here
+            recipientKey = DidUtils.IsDidKey(recipientKey)
+                ? DidUtils.ConvertDidKeyToVerkey(recipientKey)
+                : recipientKey;
 
             // Pack application level message
             var msg = await PackAsync(agentContext.Wallet, recipientKey, message.ToByteArray(), senderKey);
@@ -130,8 +135,11 @@ namespace Hyperledger.Aries.Utils
                 // or pass all keys to the PackAsync function as array?
                 foreach (var routingKey in routingKeys)
                 {
+                    var aRoutingKey = DidUtils.IsDidKey(routingKey)
+                        ? DidUtils.ConvertDidKeyToVerkey(routingKey)
+                        : routingKey;
                     // Anonpack
-                    msg = await PackAsync(agentContext.Wallet, routingKey, new ForwardMessage(agentContext.UseMessageTypesHttps) { Message = JObject.Parse(msg.GetUTF8String()), To = previousKey });
+                    msg = await PackAsync(agentContext.Wallet, aRoutingKey, new ForwardMessage(agentContext.UseMessageTypesHttps) { Message = JObject.Parse(msg.GetUTF8String()), To = previousKey });
                     previousKey = routingKey;
                 }
             }

--- a/src/Hyperledger.Aries/Utils/CryptoUtils.cs
+++ b/src/Hyperledger.Aries/Utils/CryptoUtils.cs
@@ -119,10 +119,7 @@ namespace Hyperledger.Aries.Utils
             if (message == null) throw new ArgumentNullException(nameof(message));
             if (recipientKey == null) throw new ArgumentNullException(nameof(recipientKey));
             
-            // Bookmark: Transform recipientKey and routingKeys in did:key format into verkeys here
-            recipientKey = DidUtils.IsDidKey(recipientKey)
-                ? DidUtils.ConvertDidKeyToVerkey(recipientKey)
-                : recipientKey;
+            recipientKey = DidUtils.IsDidKey(recipientKey) ? DidUtils.ConvertDidKeyToVerkey(recipientKey) : recipientKey;
 
             // Pack application level message
             var msg = await PackAsync(agentContext.Wallet, recipientKey, message.ToByteArray(), senderKey);
@@ -135,12 +132,10 @@ namespace Hyperledger.Aries.Utils
                 // or pass all keys to the PackAsync function as array?
                 foreach (var routingKey in routingKeys)
                 {
-                    var aRoutingKey = DidUtils.IsDidKey(routingKey)
-                        ? DidUtils.ConvertDidKeyToVerkey(routingKey)
-                        : routingKey;
+                    var verkey = DidUtils.IsDidKey(routingKey) ? DidUtils.ConvertDidKeyToVerkey(routingKey) : routingKey;
                     // Anonpack
-                    msg = await PackAsync(agentContext.Wallet, aRoutingKey, new ForwardMessage(agentContext.UseMessageTypesHttps) { Message = JObject.Parse(msg.GetUTF8String()), To = previousKey });
-                    previousKey = routingKey;
+                    msg = await PackAsync(agentContext.Wallet, verkey, new ForwardMessage(agentContext.UseMessageTypesHttps) { Message = JObject.Parse(msg.GetUTF8String()), To = previousKey });
+                    previousKey = verkey;
                 }
             }
 

--- a/src/Hyperledger.Aries/Utils/DidUtils.cs
+++ b/src/Hyperledger.Aries/Utils/DidUtils.cs
@@ -86,6 +86,9 @@ namespace Hyperledger.Aries.Utils
         /// <returns>Boolean indicating if the string is a valid did:key</returns>
         public static bool IsDidKey(string didKey)
         {
+            if (didKey == null) 
+                return false;
+            
             return Regex.Matches(didKey, DID_KEY_REGEX).Count == 1;
         }
         

--- a/test/Hyperledger.Aries.Tests/DidUtilsTests.cs
+++ b/test/Hyperledger.Aries.Tests/DidUtilsTests.cs
@@ -1,3 +1,4 @@
+using System;
 using Hyperledger.Aries.Utils;
 using Xunit;
 
@@ -6,12 +7,18 @@ namespace Hyperledger.Aries.Tests
     public class DidUtilsTests
     {
         private const string VALID_FULL_VERKEY = "MeHaPyPGsbBCgMKo13oWK7MeHaPyPGsbBCgMKo13oWK7";
+        private const string ANOTHER_VALID_FULL_VERKEY = "XHhCzrFBTvrh2GsmHWRW4bpGYHdiPJbagSTFEMvFayc";
         private const string VALID_ABBREVIATED_VERKEY = "~MeHaPyPGsbBCgMKo13oWK7";
+        private const string VALID_DID_KEY = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
+        private const string ORIG_VERKEY = "8HH5gYEeNc3z7PYXmd54d4x6qAfCNrqQqEB3nS7Zfu7K";
+        private const string DERIVED_DID_KEY = "did:key:z6MkmjY8GnV5i9YTDtPETC2uUAW6ejw3nk5mXF5yci5ab7th";
+        private const string VALID_SECP256K1_0 = "did:key:zQ3shokFTS3brHcDQrn82RUDfCZESWL1ZdCEJwekUDPQiYBme";
 
         [Fact]
         public void CanDetectFullVerkey()
         {
             Assert.True(DidUtils.IsFullVerkey(VALID_FULL_VERKEY)); //Valid full verkey
+            Assert.True(DidUtils.IsFullVerkey(ANOTHER_VALID_FULL_VERKEY)); // Indy seems to generate verkeys with less than 256bit (only 43 chars)
             Assert.False(DidUtils.IsFullVerkey("")); 
             Assert.False(DidUtils.IsFullVerkey(VALID_ABBREVIATED_VERKEY)); //Valid abbreviated verkey
         }
@@ -32,5 +39,35 @@ namespace Hyperledger.Aries.Tests
             Assert.False(DidUtils.IsVerkey(""));
         }
 
+        [Fact]
+        public void CanDetectDidKey()
+        {
+            Assert.True(DidUtils.IsDidKey(VALID_DID_KEY));
+            Assert.True(DidUtils.IsDidKey(VALID_SECP256K1_0));
+            Assert.False(DidUtils.IsDidKey(VALID_FULL_VERKEY));
+            Assert.False(DidUtils.IsDidKey(""));
+        }
+        
+        [Fact]
+        public void CanConvertDidKeyToVerkey()
+        {
+            var result = DidUtils.ConvertDidKeyToVerkey(DERIVED_DID_KEY);
+            
+            Assert.Equal(ORIG_VERKEY, result);
+        }
+        
+        [Fact]
+        public void CanConvertVerkeyToDidKey()
+        {
+            var result = DidUtils.ConvertVerkeyToDidKey(ORIG_VERKEY);
+            
+            Assert.Equal(DERIVED_DID_KEY, result);
+        }
+
+        [Fact]
+        public void ConvertNonEd25519KeysToDidKeyWillThrowArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => DidUtils.ConvertDidKeyToVerkey(VALID_SECP256K1_0));
+        }
     }
 }

--- a/test/Hyperledger.Aries.Tests/Integration/ConnectionTests.cs
+++ b/test/Hyperledger.Aries.Tests/Integration/ConnectionTests.cs
@@ -25,16 +25,20 @@ namespace Hyperledger.Aries.Tests.Integration
             _router.RegisterAgent(_agent2);
         }
 
-        [Fact]
-        public async Task CanConnect()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task CanConnect(bool useDidKeyFormat)
         {
-            await AgentScenarios.EstablishConnectionAsync(_agent1, _agent2);
+            await AgentScenarios.EstablishConnectionAsync(_agent1, _agent2, useDidKeyFormat);
         }
 
-        [Fact]
-        public async Task CanConnectWithReturnRouting()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task CanConnectWithReturnRouting(bool useDidKeyFormat)
         {
-            await AgentScenarios.EstablishConnectionWithReturnRoutingAsync(_agent1, _agent2);
+            await AgentScenarios.EstablishConnectionWithReturnRoutingAsync(_agent1, _agent2, useDidKeyFormat);
         }
 
         public async Task DisposeAsync()

--- a/test/Hyperledger.Aries.Tests/Integration/CredentialTests.cs
+++ b/test/Hyperledger.Aries.Tests/Integration/CredentialTests.cs
@@ -42,6 +42,18 @@ namespace Hyperledger.Aries.Tests.Integration
                 new CredentialPreviewAttribute("last_name", "Holder")
             });
         }
+        
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task CanIssueCredentialConnectionless(bool useDidKeyFormat)
+        {
+            await AgentScenarios.IssueCredentialConnectionlessAsync(_issuerAgent, _holderAgent, new List<CredentialPreviewAttribute>
+            {
+                new CredentialPreviewAttribute("first_name", "Test"),
+                new CredentialPreviewAttribute("last_name", "Holder")
+            }, useDidKeyFormat);
+        }
 
         public async Task DisposeAsync()
         {

--- a/test/Hyperledger.Aries.Tests/Integration/ProofTests.cs
+++ b/test/Hyperledger.Aries.Tests/Integration/ProofTests.cs
@@ -1,13 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Hyperledger.TestHarness;
-using Hyperledger.TestHarness.Mock;
-using Hyperledger.Indy.AnonCredsApi;
-using Xunit;
 using Hyperledger.Aries.Features.IssueCredential;
 using Hyperledger.Aries.Features.PresentProof;
 using Hyperledger.Aries.Storage;
+using Hyperledger.Indy.AnonCredsApi;
+using Hyperledger.TestHarness;
+using Hyperledger.TestHarness.Mock;
+using Xunit;
 
 namespace Hyperledger.Aries.Tests.Integration
 {
@@ -62,6 +62,31 @@ namespace Hyperledger.Aries.Tests.Integration
                         {"first-name-requirement", new ProofAttributeInfo {Name = "first_name"}}
                     }
                 });
+        }
+        
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task CanPerformProofProtocolConnectionless(bool useDidKeyFormat)
+        {
+            (var issuerConnection, var holderConnection)  = await AgentScenarios.EstablishConnectionAsync(_issuerAgent, _holderAgent);
+
+            await AgentScenarios.IssueCredentialAsync(_issuerAgent, _holderAgent, issuerConnection, holderConnection, new List<CredentialPreviewAttribute>
+            {
+                new CredentialPreviewAttribute("first_name", "Test"),
+                new CredentialPreviewAttribute("last_name", "Holder")
+            });
+            
+            await AgentScenarios.ProofProtocolConnectionlessAsync(_requestorAgent, _holderAgent, new ProofRequest()
+                {
+                    Name = "ProofReq",
+                    Version = "1.0",
+                    Nonce = await AnonCreds.GenerateNonceAsync(),
+                    RequestedAttributes = new Dictionary<string, ProofAttributeInfo>
+                    {
+                        {"first-name-requirement", new ProofAttributeInfo {Name = "first_name"}}
+                    }
+                }, useDidKeyFormat);
         }
 
         public async Task DisposeAsync()

--- a/test/Hyperledger.Aries.Tests/Protocols/ConnectionTests.cs
+++ b/test/Hyperledger.Aries.Tests/Protocols/ConnectionTests.cs
@@ -1,20 +1,21 @@
 ﻿using System;
 using System.Collections.Concurrent;
+using System.Linq;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
-using Hyperledger.Aries.Contracts;
 using Hyperledger.Aries.Agents;
+using Hyperledger.Aries.Configuration;
+using Hyperledger.Aries.Contracts;
+using Hyperledger.Aries.Features.DidExchange;
 using Hyperledger.Aries.Models.Events;
 using Hyperledger.Aries.Runtime;
+using Hyperledger.Aries.Storage;
+using Hyperledger.Indy.WalletApi;
 using Hyperledger.TestHarness;
 using Hyperledger.TestHarness.Utils;
-using Hyperledger.Indy.WalletApi;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
-using Hyperledger.Aries.Features.DidExchange;
-using Hyperledger.Aries.Configuration;
-using Hyperledger.Aries.Storage;
 
 namespace Hyperledger.Aries.Tests.Protocols
 {
@@ -58,11 +59,27 @@ namespace Hyperledger.Aries.Tests.Protocols
         {
             var connectionId = Guid.NewGuid().ToString();
 
-            await _connectionService.CreateInvitationAsync(_issuerWallet,
+            var (msg , record) = await _connectionService.CreateInvitationAsync(_issuerWallet,
                 new InviteConfiguration { ConnectionId = connectionId });
 
             var connection = await _connectionService.GetAsync(_issuerWallet, connectionId);
 
+            Assert.False(connection.MultiPartyInvitation);
+            Assert.Equal(ConnectionState.Invited, connection.State);
+            Assert.Equal(connectionId, connection.Id);
+        }
+        
+        [Fact]
+        public async Task CanCreateInvitationWithDidKeyFormatAsync()
+        {
+            var connectionId = Guid.NewGuid().ToString();
+
+            var (msg, record) = await _connectionService.CreateInvitationAsync(_issuerWallet,
+                new InviteConfiguration { ConnectionId = connectionId, UseDidKeyFormat = true});
+
+            var connection = await _connectionService.GetAsync(_issuerWallet, connectionId);
+
+            Assert.True(DidUtils.IsDidKey(msg.RecipientKeys.First()));
             Assert.False(connection.MultiPartyInvitation);
             Assert.Equal(ConnectionState.Invited, connection.State);
             Assert.Equal(connectionId, connection.Id);
@@ -241,8 +258,10 @@ namespace Hyperledger.Aries.Tests.Protocols
             Assert.True(ex.ErrorCode == ErrorCode.RecordNotFound);
         }
 
-        [Fact]
-        public async Task CanEstablishConnectionAsync()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task CanEstablishConnectionAsync(bool useDidKeyFormat)
         {
             var events = 0;
             _eventAggregator.GetEventByType<ServiceMessageProcessingEvent>()
@@ -255,7 +274,7 @@ namespace Hyperledger.Aries.Tests.Protocols
 
 
             var (connectionIssuer, connectionHolder) = await Scenarios.EstablishConnectionAsync(
-                _connectionService, _messages, _issuerWallet, _holderWallet);
+                _connectionService, _messages, _issuerWallet, _holderWallet, useDidKeyFormat: useDidKeyFormat);
 
             Assert.True(events == 2);
 

--- a/test/Hyperledger.Aries.Tests/Protocols/ConnectionTests.cs
+++ b/test/Hyperledger.Aries.Tests/Protocols/ConnectionTests.cs
@@ -10,6 +10,7 @@ using Hyperledger.Aries.Features.DidExchange;
 using Hyperledger.Aries.Models.Events;
 using Hyperledger.Aries.Runtime;
 using Hyperledger.Aries.Storage;
+using Hyperledger.Aries.Utils;
 using Hyperledger.Indy.WalletApi;
 using Hyperledger.TestHarness;
 using Hyperledger.TestHarness.Utils;

--- a/test/Hyperledger.Aries.Tests/Protocols/ConnectionTests.cs
+++ b/test/Hyperledger.Aries.Tests/Protocols/ConnectionTests.cs
@@ -80,6 +80,7 @@ namespace Hyperledger.Aries.Tests.Protocols
             var connection = await _connectionService.GetAsync(_issuerWallet, connectionId);
 
             Assert.True(DidUtils.IsDidKey(msg.RecipientKeys.First()));
+            Assert.True(DidUtils.IsDidKey(msg.RoutingKeys.First()));
             Assert.False(connection.MultiPartyInvitation);
             Assert.Equal(ConnectionState.Invited, connection.State);
             Assert.Equal(connectionId, connection.Id);


### PR DESCRIPTION
#### Short description of what this resolves:
This PR adds the ability to transform did:key into verkeys and verkeys into their did:key representation as described in [RFC-0360](https://github.com/hyperledger/aries-rfcs/tree/b3a3942ef052039e73cd23d847f42947f8287da2/features/0360-use-did-key).

#### Changes proposed in this pull request:

- Added method in DidUtils to transform verkey into did:key
- Enable did:key usage in connection invitation and service decorators
- Added integration tests for connectionless presentation and issuance
