### PR TITLE
Initial oob implementation with handshake reuse

### DIFF
--- a/src/Hyperledger.Aries.Routing.Edge/EdgeClientService.Backup.cs
+++ b/src/Hyperledger.Aries.Routing.Edge/EdgeClientService.Backup.cs
@@ -1,18 +1,18 @@
-﻿using Hyperledger.Aries.Agents;
-using Hyperledger.Aries.Decorators.Attachments;
-using Hyperledger.Aries.Extensions;
-using Hyperledger.Aries.Features.IssueCredential;
-using Hyperledger.Indy.CryptoApi;
-using Multiformats.Base;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using Hyperledger.Indy.WalletApi;
-using Hyperledger.Indy.DidApi;
-using Hyperledger.Indy;
+using Hyperledger.Aries.Agents;
 using Hyperledger.Aries.Configuration;
+using Hyperledger.Aries.Decorators.Attachments;
+using Hyperledger.Aries.Extensions;
+using Hyperledger.Aries.Features.IssueCredential;
+using Hyperledger.Indy;
+using Hyperledger.Indy.CryptoApi;
+using Hyperledger.Indy.DidApi;
+using Hyperledger.Indy.WalletApi;
+using Multiformats.Base;
 using Newtonsoft.Json;
 
 namespace Hyperledger.Aries.Routing.Edge
@@ -148,7 +148,7 @@ namespace Hyperledger.Aries.Routing.Edge
                 // Add 1 sec delay to allow filesystem to catch up
                 await Task.Delay(TimeSpan.FromSeconds(1));
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 Console.WriteLine("Wallet could not be deleted");
             }

--- a/src/Hyperledger.Aries.TestHarness/Mock/MockAgent.cs
+++ b/src/Hyperledger.Aries.TestHarness/Mock/MockAgent.cs
@@ -26,6 +26,7 @@ namespace Hyperledger.TestHarness.Mock
 
         protected override void ConfigureHandlers()
         {
+            AddOutOfBandHandler();
             AddConnectionHandler();
             AddDidExchangeHandler();
             AddForwardHandler();

--- a/src/Hyperledger.Aries/Agents/AgentBase.cs
+++ b/src/Hyperledger.Aries/Agents/AgentBase.cs
@@ -9,6 +9,7 @@ using Hyperledger.Aries.Features.Handshakes.Common;
 using Hyperledger.Aries.Features.Handshakes.Connection;
 using Hyperledger.Aries.Features.Handshakes.DidExchange;
 using Hyperledger.Aries.Features.IssueCredential;
+using Hyperledger.Aries.Features.OutOfBand;
 using Hyperledger.Aries.Features.PresentProof;
 using Hyperledger.Aries.Features.RevocationNotification;
 using Hyperledger.Aries.Features.Routing;
@@ -62,6 +63,9 @@ namespace Hyperledger.Aries.Agents
             Middlewares = provider.GetServices<IAgentMiddleware>();
         }
 
+        /// <summary>Adds a handler for supporting default out-of-band flows.</summary>
+        protected void AddOutOfBandHandler() => Handlers.Add(Provider.GetRequiredService<DefaultOutOfBandHandler>());
+        
         /// <summary>Adds a handler for supporting default connection flow.</summary>
         protected void AddConnectionHandler() => Handlers.Add(Provider.GetRequiredService<DefaultConnectionHandler>());
 

--- a/src/Hyperledger.Aries/Agents/DefaultAgent.cs
+++ b/src/Hyperledger.Aries/Agents/DefaultAgent.cs
@@ -20,6 +20,7 @@ namespace Hyperledger.Aries.Agents
         /// </summary>
         protected override void ConfigureHandlers()
         {
+            AddOutOfBandHandler();
             AddConnectionHandler();
             AddCredentialHandler();
             AddDidExchangeHandler();

--- a/src/Hyperledger.Aries/Agents/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Hyperledger.Aries/Agents/Extensions/ServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@ using Hyperledger.Aries.Features.Discovery;
 using Hyperledger.Aries.Features.Handshakes.Connection;
 using Hyperledger.Aries.Features.Handshakes.DidExchange;
 using Hyperledger.Aries.Features.IssueCredential;
+using Hyperledger.Aries.Features.OutOfBand;
 using Hyperledger.Aries.Features.PresentProof;
 using Hyperledger.Aries.Features.RevocationNotification;
 using Hyperledger.Aries.Features.Routing;
@@ -29,6 +30,7 @@ namespace Microsoft.Extensions.DependencyInjection
             collection.AddTransient<DefaultTrustPingMessageHandler>();
             collection.AddTransient<DefaultDiscoveryHandler>();
             collection.AddTransient<DefaultBasicMessageHandler>();
+            collection.AddTransient<DefaultOutOfBandHandler>();
             collection.AddTransient<DefaultRevocationNotificationHandler>();
         }
 

--- a/src/Hyperledger.Aries/Agents/MessageTypesHttps.cs
+++ b/src/Hyperledger.Aries/Agents/MessageTypesHttps.cs
@@ -54,6 +54,20 @@
         /// Discovery Disclose Message Type.
         /// </summary>
         public const string DiscoveryDiscloseMessageType = "https://didcomm.org/discover-features/1.0/disclose";
+        
+        /// <summary>
+        /// Out of band message types
+        /// </summary>
+        public static class OutOfBand
+        {
+            public const string Invitation = "https://didcomm.org/out-of-band/1.1/invitation";
+
+            public const string HandshakeReuse = "https://didcomm.org/out-of-band/1.1/handshake-reuse";
+
+            public const string HandshakeReuseAccepted = "https://didcomm.org/out-of-band/1.1/handshake-reuse-accepted";
+
+            public const string ProblemReport = "https://didcomm.org/out-of-band/1.1/problem_report";
+        }
 
         /// <summary>
         /// Acknowledge Revocation Notification Message Type.

--- a/src/Hyperledger.Aries/Agents/MessageTypesHttps.cs
+++ b/src/Hyperledger.Aries/Agents/MessageTypesHttps.cs
@@ -72,14 +72,14 @@
         /// <summary>
         /// Acknowledge Revocation Notification Message Type.
         /// </summary>
-        public const string RevocationNotificationAcknowledgement =
-            "https://didcomm.org/revocation_notification/1.0/ack";
+        public const string RevocationNotificationAcknowledgement = "https://didcomm.org/revocation_notification/1.0/ack";
         
         /// <summary>
         /// Revocation Notification Message Type.
         /// </summary>
-        public const string RevocationNotification =
-            "https://didcomm.org/revocation_notification/1.0/revoke";
+        public const string RevocationNotification = "https://didcomm.org/revocation_notification/1.0/revoke";
+        
+        /// <summary>
         /// Did Exchange Message Types
         /// </summary>
         public static class DidExchange

--- a/src/Hyperledger.Aries/Agents/Transport/MessageServiceExtensions.cs
+++ b/src/Hyperledger.Aries/Agents/Transport/MessageServiceExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using Hyperledger.Aries.Features.Handshakes.Common;
+using Hyperledger.Aries.Utils;
 
 namespace Hyperledger.Aries.Agents
 {
@@ -20,7 +21,7 @@ namespace Hyperledger.Aries.Agents
         public static async Task SendAsync(this IMessageService service, IAgentContext agentContext, AgentMessage message, ConnectionRecord connection)
         {
             var routingKeys = connection.Endpoint?.Verkey != null ? connection.Endpoint.Verkey : new string[0];
-            var recipientKey = connection.TheirVk ?? connection.GetTag("InvitationKey") ?? throw new InvalidOperationException("Cannot locate a recipient key");
+            var recipientKey = connection.TheirVk ?? connection.GetTag(TagConstants.InvitationKey) ?? throw new InvalidOperationException("Cannot locate a recipient key");
 
             if (connection.Endpoint?.Uri == null)
                 throw new AriesFrameworkException(ErrorCode.A2AMessageTransmissionError, "Cannot send to connection that does not have endpoint information specified");
@@ -40,7 +41,7 @@ namespace Hyperledger.Aries.Agents
         public static async Task<MessageContext> SendReceiveAsync(this IMessageService service, IAgentContext agentContext, AgentMessage message, ConnectionRecord connection)
         {
             var routingKeys = connection.Endpoint?.Verkey != null ? connection.Endpoint.Verkey : new string[0];
-            var recipientKey = connection.TheirVk ?? connection.GetTag("InvitationKey") ?? throw new InvalidOperationException("Cannot locate a recipient key");
+            var recipientKey = connection.TheirVk ?? connection.GetTag(TagConstants.InvitationKey) ?? throw new InvalidOperationException("Cannot locate a recipient key");
 
             if (connection.Endpoint?.Uri == null)
                 throw new AriesFrameworkException(ErrorCode.A2AMessageTransmissionError, "Cannot send to connection that does not have endpoint information specified");

--- a/src/Hyperledger.Aries/Common/ErrorCode.cs
+++ b/src/Hyperledger.Aries/Common/ErrorCode.cs
@@ -66,6 +66,14 @@
         /// <summary>
         /// Item not found on ledger
         /// </summary>
-        LedgerItemNotFound
+        LedgerItemNotFound,
+        /// <summary>
+        /// No public did was provisioned
+        /// </summary>
+        NoPublicDid,
+        /// <summary>
+        /// The did method is not supported
+        /// </summary>
+        UnsupportedDidMethod
     }
 }

--- a/src/Hyperledger.Aries/Common/MediaTypes.cs
+++ b/src/Hyperledger.Aries/Common/MediaTypes.cs
@@ -1,0 +1,9 @@
+namespace Hyperledger.Aries.Common
+{
+    public static class MediaTypes
+    {
+        public const string EncryptionEnvelopeV2 = "didcomm/aip2;env=rfc587";
+        
+        public const string EncryptionEnvelopeV1 = "didcomm/aip2;env=rfc19";
+    }
+}

--- a/src/Hyperledger.Aries/Configuration/ServiceCollectionExtensions.cs
+++ b/src/Hyperledger.Aries/Configuration/ServiceCollectionExtensions.cs
@@ -6,6 +6,7 @@ using Hyperledger.Aries.Features.Discovery;
 using Hyperledger.Aries.Features.Handshakes.Connection;
 using Hyperledger.Aries.Features.Handshakes.DidExchange;
 using Hyperledger.Aries.Features.IssueCredential;
+using Hyperledger.Aries.Features.OutOfBand;
 using Hyperledger.Aries.Features.PresentProof;
 using Hyperledger.Aries.Features.RevocationNotification;
 using Hyperledger.Aries.Ledger;
@@ -52,6 +53,7 @@ namespace Microsoft.Extensions.DependencyInjection
         internal static IServiceCollection AddDefaultServices(this IServiceCollection builder)
         {
             builder.TryAddSingleton<IEventAggregator, EventAggregator>();
+            builder.TryAddSingleton<IOutOfBandService, DefaultOutOfBandService>();
             builder.TryAddSingleton<IConnectionService, DefaultConnectionService>();
             builder.TryAddSingleton<ICredentialService, DefaultCredentialService>();
             builder.TryAddSingleton<IDidExchangeService, DefaultDidExchangeService>();

--- a/src/Hyperledger.Aries/Decorators/Attachments/AttachmentContent.cs
+++ b/src/Hyperledger.Aries/Decorators/Attachments/AttachmentContent.cs
@@ -42,5 +42,14 @@ namespace Hyperledger.Aries.Decorators.Attachments
         /// </value>
         [JsonProperty("jws", NullValueHandling = NullValueHandling.Ignore)]
         public JsonWebSignature JsonWebSignature { get; set; }
+        
+        /// <summary>
+        /// Get or sets a json
+        /// </summary>
+        /// <value>
+        /// The json object as string.
+        /// </value>
+        [JsonProperty("json", NullValueHandling = NullValueHandling.Ignore)]
+        public string Json { get; set; }
     }
 }

--- a/src/Hyperledger.Aries/Decorators/Threading/ThreadDecoratorExtensions.cs
+++ b/src/Hyperledger.Aries/Decorators/Threading/ThreadDecoratorExtensions.cs
@@ -68,17 +68,40 @@ namespace Hyperledger.Aries.Decorators.Threading
 
             return threadId;
         }
+        
+        /// <summary>
+        /// Gets the current messages parent thread id.
+        /// </summary>
+        /// <param name="message">Message to extract the parent thread id from.</param>
+        /// <returns>Parent thread id of the message.</returns>
+        public static string GetParentThreadId(this AgentMessage message)
+        {
+            string threadId = null;
+            try
+            {
+                var threadBlock = message.GetDecorator<ThreadDecorator>(DecoratorIdentifier);
+                threadId = threadBlock.ParentThreadId;
+            }
+            catch (Exception)
+            {
+                // ignored
+            }
+
+            return threadId;
+        }
 
         /// <summary>
         /// Threads the current message.
         /// </summary>
         /// <param name="messageToThread">Message to thread.</param>
         /// <param name="threadId">Thread id to thread the message with.</param>
-        public static void ThreadFrom(this AgentMessage messageToThread, string threadId)
+        /// <param name="parentThreadId">Parent thread id to thread the message with.</param>
+        public static void ThreadFrom(this AgentMessage messageToThread, string threadId, string parentThreadId = null)
         {
             var currentThreadContext = new ThreadDecorator
             {
-                ThreadId = threadId
+                ThreadId = threadId,
+                ParentThreadId = parentThreadId
             };
             messageToThread.AddDecorator(currentThreadContext, DecoratorIdentifier);
         }

--- a/src/Hyperledger.Aries/Features/Handshakes/Common/ConnectionRecord.cs
+++ b/src/Hyperledger.Aries/Features/Handshakes/Common/ConnectionRecord.cs
@@ -133,7 +133,7 @@ namespace Hyperledger.Aries.Features.Handshakes.Common
         /// <summary>
         /// My role in the handshake protocol 
         /// </summary>
-        [JsonIgnore]
+        [JsonConverter(typeof(StringEnumConverter))]
         public ConnectionRole Role
         {
             get;

--- a/src/Hyperledger.Aries/Features/Handshakes/Common/ConnectionRecord.cs
+++ b/src/Hyperledger.Aries/Features/Handshakes/Common/ConnectionRecord.cs
@@ -173,7 +173,9 @@ namespace Hyperledger.Aries.Features.Handshakes.Common
         private StateMachine<ConnectionState, ConnectionTrigger> GetStateMachine()
         {
             var state = new StateMachine<ConnectionState, ConnectionTrigger>(() => State, x => State = x);
+#pragma warning disable CS0618
             state.Configure(ConnectionState.Invited).Permit(ConnectionTrigger.InvitationAccept, ConnectionState.Negotiating);
+#pragma warning restore CS0618
             state.Configure(ConnectionState.Invited).Permit(ConnectionTrigger.Request, ConnectionState.Negotiating);
             state.Configure(ConnectionState.Invited).Permit(ConnectionTrigger.Abandon, ConnectionState.Abandoned);
             state.Configure(ConnectionState.Negotiating).Permit(ConnectionTrigger.Response, ConnectionState.Connected);

--- a/src/Hyperledger.Aries/Features/Handshakes/Common/Dids/DidCommServiceEndpoint.cs
+++ b/src/Hyperledger.Aries/Features/Handshakes/Common/Dids/DidCommServiceEndpoint.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Hyperledger.Aries.Features.Handshakes.Common.Dids
+{
+    public class DidCommServiceEndpoint : IDidDocServiceEndpoint
+    {
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        [JsonProperty("type")] 
+        public string Type => DidDocServiceEndpointTypes.DidCommunication;
+        
+        [JsonProperty("priority")]
+        public int Priority { get; set; }
+        
+        [JsonProperty("recipientKeys")]
+        public IList<string> RecipientKeys { get; set; }
+
+        [JsonProperty("routingKeys")]
+        public IList<string> RoutingKeys { get; set; }
+        
+        [JsonProperty("accept")]
+        public IList<string> Accept { get; set; }
+        
+        [JsonProperty("serviceEndpoint")]
+        public string ServiceEndpoint { get; set; }
+    }
+}

--- a/src/Hyperledger.Aries/Features/Handshakes/Common/Dids/DidDocServiceEndpointTypes.cs
+++ b/src/Hyperledger.Aries/Features/Handshakes/Common/Dids/DidDocServiceEndpointTypes.cs
@@ -9,5 +9,11 @@
         /// The indy agent.
         /// </summary>
         public const string IndyAgent = "IndyAgent";
+
+        /// <summary>
+        /// Did communication service endpoint
+        /// https://github.com/hyperledger/aries-rfcs/blob/main/features/0067-didcomm-diddoc-conventions/README.md#service-conventions
+        /// </summary>
+        public const string DidCommunication = "did-communication";
     }
 }

--- a/src/Hyperledger.Aries/Features/Handshakes/Connection/IConnectionService.cs
+++ b/src/Hyperledger.Aries/Features/Handshakes/Connection/IConnectionService.cs
@@ -5,6 +5,7 @@ using Hyperledger.Aries.Agents;
 using Hyperledger.Aries.Common;
 using Hyperledger.Aries.Features.Handshakes.Common;
 using Hyperledger.Aries.Features.Handshakes.Connection.Models;
+using Hyperledger.Aries.Features.OutOfBand;
 using Hyperledger.Aries.Storage;
 
 namespace Hyperledger.Aries.Features.Handshakes.Connection
@@ -59,6 +60,14 @@ namespace Hyperledger.Aries.Features.Handshakes.Connection
         /// <param name="offer">Connection offer message</param>
         /// <returns>The new connection record.</returns>
         Task<ConnectionRecord> ProcessInvitationAsync(IAgentContext agentContext, ConnectionInvitationMessage offer);
+
+        /// <summary>
+        /// Process an out-of-band invitation
+        /// </summary>
+        /// <param name="agentContext">Agent context.</param>
+        /// <param name="invitation">Out-of-band invitation message</param>
+        /// <returns>The <see cref="ConnectionRecord"/></returns>
+        Task<ConnectionRecord> ProcessInvitationAsync(IAgentContext agentContext, InvitationMessage invitation);
 
         /// <summary>
         /// Accepts an existing invitation.

--- a/src/Hyperledger.Aries/Features/Handshakes/Connection/Models/InviteConfiguration.cs
+++ b/src/Hyperledger.Aries/Features/Handshakes/Connection/Models/InviteConfiguration.cs
@@ -44,6 +44,11 @@ namespace Hyperledger.Aries.Features.Handshakes.Connection.Models
         public bool UseDidKeyFormat { get; set; } = false;
 
         /// <summary>
+        /// Indicator if this invitation should keep the 
+        /// </summary>
+        public bool UsePublicDid { get; set; } = false;
+
+        /// <summary>
         /// Controls the tags that are persisted against the invite/connection record.
         /// </summary>
         public Dictionary<string, string> Tags { get; set; } = new Dictionary<string, string>();

--- a/src/Hyperledger.Aries/Features/Handshakes/DidExchange/DefaultDidExchangeHandler.cs
+++ b/src/Hyperledger.Aries/Features/Handshakes/DidExchange/DefaultDidExchangeHandler.cs
@@ -31,7 +31,7 @@ namespace Hyperledger.Aries.Features.Handshakes.DidExchange
                     var request = messageContext.GetMessage<DidExchangeRequestMessage>();
                     try
                     {
-                        await _didExchangeService.ProcessRequestAsync(agentContext, request);
+                        await _didExchangeService.ProcessRequestAsync(agentContext, request, messageContext.Connection);
                     }
                     catch (Exception)
                     {

--- a/src/Hyperledger.Aries/Features/Handshakes/DidExchange/DefaultDidExchangeService.cs
+++ b/src/Hyperledger.Aries/Features/Handshakes/DidExchange/DefaultDidExchangeService.cs
@@ -10,6 +10,7 @@ using Hyperledger.Aries.Extensions;
 using Hyperledger.Aries.Features.Handshakes.Common;
 using Hyperledger.Aries.Features.Handshakes.Common.Dids;
 using Hyperledger.Aries.Features.Handshakes.DidExchange.Models;
+using Hyperledger.Aries.Features.OutOfBand;
 using Hyperledger.Aries.Models.Events;
 using Hyperledger.Aries.Storage;
 using Hyperledger.Aries.Utils;
@@ -35,16 +36,56 @@ namespace Hyperledger.Aries.Features.Handshakes.DidExchange
         }
 
         /// <inheritdoc/>
-        public Task<(DidExchangeRequestMessage, ConnectionRecord)> CreateRequestAsync(IAgentContext agentContext, AgentMessage message)
+        public async Task<ConnectionRecord> ProcessInvitationAsync(IAgentContext agentContext, InvitationMessage invitation)
         {
-            // Todo: Create request based on out-of-band message
-            throw new NotImplementedException();
+            if (invitation.HandshakeProtocols.Contains(HandshakeProtocolUri.DidExchange) == false)
+                throw new NotImplementedException("The given handshake protocols are not implemented.");
+
+            ConnectionRecord connectionRecord = null;
+            if (invitation.Services.FirstOrDefault() is DidCommServiceEndpoint didCommService)
+            {
+                DidUtils.EnsureQualifiedDid(didCommService.RecipientKeys.First());
+                connectionRecord = new ConnectionRecord
+                {
+                    Endpoint = new AgentEndpoint {Uri = didCommService.ServiceEndpoint},
+                    Alias = new ConnectionAlias {Name = invitation.Label},
+                    HandshakeProtocol = HandshakeProtocol.DidExchange,
+                    Role = ConnectionRole.Invitee,
+                    TheirDid = DidUtils.EnsureQualifiedDid(didCommService.RecipientKeys.First()),
+                    TheirVk = didCommService.RecipientKeys.First(),
+                    State = ConnectionState.Invited
+                };
+            }
+            else if (invitation.Services.FirstOrDefault() is string resolvableDid)
+            {
+                var recipientKey = await Did.KeyForDidAsync(await agentContext.Pool, agentContext.Wallet, resolvableDid);
+                var endpointResult = await _ledgerService.LookupServiceEndpointAsync(agentContext, resolvableDid);
+
+                connectionRecord = new ConnectionRecord
+                {
+                    Endpoint = new AgentEndpoint {Uri = endpointResult.Result.Endpoint},
+                    Alias = new ConnectionAlias {Name = invitation.Label},
+                    HandshakeProtocol = HandshakeProtocol.DidExchange,
+                    Role = ConnectionRole.Invitee,
+                    TheirDid = resolvableDid,
+                    TheirVk = recipientKey,
+                    State = ConnectionState.Invited
+                };
+            }
+            
+            if (connectionRecord == null) throw new NotImplementedException();
+            
+            connectionRecord.SetTag(TagConstants.ParentThreadId, invitation.GetThreadId());
+            
+            await _recordService.AddAsync(agentContext.Wallet, connectionRecord);
+
+            return connectionRecord;
         }
 
         /// <inheritdoc/>
         public async Task<(DidExchangeRequestMessage, ConnectionRecord)> CreateRequestAsync(IAgentContext agentContext, string did)
         {
-            var key = await Did.KeyForDidAsync(await agentContext.Pool, agentContext.Wallet, did);
+            var theirVerkey = await Did.KeyForDidAsync(await agentContext.Pool, agentContext.Wallet, did);
             var endpointResult = await _ledgerService.LookupServiceEndpointAsync(agentContext, did);
             
             var myDid = await Did.CreateAndStoreMyDidAsync(agentContext.Wallet, "{}");
@@ -55,11 +96,10 @@ namespace Hyperledger.Aries.Features.Handshakes.DidExchange
                 MyDid = DidUtils.ConvertVerkeyToDidKey(myDid.VerKey),
                 MyVk = myDid.VerKey,
                 TheirDid = did,
-                TheirVk = key,
+                TheirVk = theirVerkey,
                 State = ConnectionState.Negotiating,
             };
-            await _recordService.AddAsync(agentContext.Wallet, connection);
-
+            
             var provisioningRecord = await _provisioningService.GetProvisioningAsync(agentContext.Wallet);
 
             var didDoc = new AttachmentContent
@@ -79,14 +119,64 @@ namespace Hyperledger.Aries.Features.Handshakes.DidExchange
                 Label = provisioningRecord.Owner.Name,
                 DidDoc = attachment
             };
+            request.ThreadFrom(request.Id, $"{did}#didcomm");
+            
+            connection.SetTag(TagConstants.LastThreadId, request.GetThreadId());
+            connection.SetTag(TagConstants.ParentThreadId, request.GetParentThreadId());
+            
+            await _recordService.AddAsync(agentContext.Wallet, connection);
 
             return (request, connection);
         }
 
-        /// <inheritdoc/>
-        public async Task<ConnectionRecord> ProcessRequestAsync(IAgentContext agentContext, DidExchangeRequestMessage requestMessage)
+        public async Task<(DidExchangeRequestMessage, ConnectionRecord)> CreateRequestAsync(IAgentContext agentContext, ConnectionRecord record)
         {
+            await record.TriggerAsync(ConnectionTrigger.Request);
+            
             var myDid = await Did.CreateAndStoreMyDidAsync(agentContext.Wallet, "{}");
+            record.MyDid = DidUtils.ConvertVerkeyToDidKey(myDid.VerKey);
+            record.MyVk = myDid.VerKey;
+
+            var provisioningRecord = await _provisioningService.GetProvisioningAsync(agentContext.Wallet);
+            var didDoc = new AttachmentContent
+                {Base64 = record.MyDidDoc(provisioningRecord).ToJson().ToBase64Url()};
+            await didDoc.SignWithJsonWebSignature(agentContext.Wallet, myDid.VerKey);
+            
+            var attachment = new Attachment
+            {
+                Id = Guid.NewGuid().ToString(),
+                MimeType = "application/json",
+                Data = didDoc
+            };
+            
+            var request = new DidExchangeRequestMessage
+            {
+                Did = record.MyDid,
+                Label = provisioningRecord.Owner.Name,
+                DidDoc = attachment
+            };
+
+            var parentThread = record.GetTag(TagConstants.ParentThreadId);
+            if (string.IsNullOrEmpty(parentThread)) throw new NotImplementedException();
+            
+            request.ThreadFrom(request.Id, parentThread);
+            record.SetTag(TagConstants.LastThreadId, request.Id);
+
+            await _recordService.UpdateAsync(agentContext.Wallet, record);
+
+            return (request, record);
+        }
+
+        /// <inheritdoc/>
+        public async Task<ConnectionRecord> ProcessRequestAsync(IAgentContext agentContext,
+            DidExchangeRequestMessage requestMessage, ConnectionRecord record = null)
+        {
+            var existingConnectionRecords = await _recordService.SearchAsync<ConnectionRecord>(agentContext.Wallet,
+                SearchQuery.Equal(TagConstants.ParentThreadId, requestMessage.GetParentThreadId()));
+            record ??= existingConnectionRecords?.SingleOrDefault();
+            
+            if(record != null)
+                await record.TriggerAsync(ConnectionTrigger.Request);
 
             DidDoc didDoc = null;
             if (requestMessage.DidDoc.Data.Base64 is { } data)
@@ -110,55 +200,78 @@ namespace Hyperledger.Aries.Features.Handshakes.DidExchange
             }
 
             var indyService = (IndyAgentDidDocService)didDoc.Services.First(service => service is IndyAgentDidDocService);
-
             var agentEndpoint = new AgentEndpoint(indyService.ServiceEndpoint, null, indyService.RoutingKeys.ToArray());
-            
-            var connectionRecord = new ConnectionRecord
-            {
-                Id = Guid.NewGuid().ToString(),
-                Alias = new ConnectionAlias {Name = requestMessage.Label},
-                MyDid = DidUtils.ConvertVerkeyToDidKey(myDid.VerKey),
-                MyVk = myDid.VerKey,
-                TheirDid = requestMessage.Did,
-                TheirVk = didDoc.Keys.FirstOrDefault(key => key.Controller == requestMessage.Did)?.PublicKeyBase58 
-                          ?? throw new NullReferenceException("Missing public for controller"),
-                Endpoint = agentEndpoint,
-                State = ConnectionState.Negotiating
-            };
-            await _recordService.AddAsync(agentContext.Wallet, connectionRecord);
 
+            if (record is { } connectionRecord)
+            {
+                record.Alias = new ConnectionAlias {Name = requestMessage.Label};
+                record.TheirDid = requestMessage.Did;
+                record.TheirVk = didDoc.Keys.FirstOrDefault(key => key.Controller == requestMessage.Did)?.PublicKeyBase58
+                                 ?? throw new NullReferenceException("Missing public for controller");
+                record.Endpoint = agentEndpoint;
+                
+                record.SetTag(TagConstants.LastThreadId, requestMessage.Id);
+                await _recordService.UpdateAsync(agentContext.Wallet, record);
+            }
+            else
+            {
+                record = new ConnectionRecord
+                {
+                    Id = Guid.NewGuid().ToString(),
+                    Alias = new ConnectionAlias {Name = requestMessage.Label},
+                    TheirDid = requestMessage.Did,
+                    TheirVk = didDoc.Keys.FirstOrDefault(key => key.Controller == requestMessage.Did)?.PublicKeyBase58 
+                              ?? throw new NullReferenceException("Missing public for controller"),
+                    Endpoint = agentEndpoint,
+                    State = ConnectionState.Negotiating
+                };
+                
+                record.SetTag(TagConstants.LastThreadId, requestMessage.GetThreadId());
+                record.SetTag(TagConstants.ParentThreadId, requestMessage.GetParentThreadId());
+                await _recordService.AddAsync(agentContext.Wallet, record);
+            }
+            
             _eventAggregator.Publish(
                 new ServiceMessageProcessingEvent
                 {
                     MessageType = requestMessage.Type,
-                    RecordId = connectionRecord.Id,
+                    RecordId = record.Id,
                     ThreadId = requestMessage.GetThreadId()
                 });
 
-            return connectionRecord;
+            return record;
         }
 
         /// <inheritdoc/>
         public async Task<(DidExchangeResponseMessage, ConnectionRecord)> CreateResponseAsync(IAgentContext agentContext, ConnectionRecord connectionRecord)
         {
             await connectionRecord.TriggerAsync(ConnectionTrigger.Response);
-            
-            var myDid = await Did.CreateAndStoreMyDidAsync(agentContext.Wallet, "{}");
 
-            connectionRecord.MyDid = DidUtils.ConvertVerkeyToDidKey(myDid.VerKey);
-            connectionRecord.MyVk = myDid.VerKey;
-
-            var provisioningRecord = await _provisioningService.GetProvisioningAsync(agentContext.Wallet);
-            var didDoc = new AttachmentContent
-                {Base64 = connectionRecord.MyDidDoc(provisioningRecord).ToJson().ToBase64Url()};
-            await didDoc.SignWithJsonWebSignature(agentContext.Wallet, myDid.VerKey);
-            
-            var attachment = new Attachment
+            Attachment attachment = null;
+            if (connectionRecord.GetTag(TagConstants.UsePublicDid) == "true")
             {
-                Id = Guid.NewGuid().ToString(),
-                MimeType = "application/json",
-                Data = didDoc
-            };
+                var provisioning = await _provisioningService.GetProvisioningAsync(agentContext.Wallet);
+                connectionRecord.MyDid = DidUtils.ToDid(DidUtils.DidSovMethodSpec, provisioning.IssuerDid) ?? throw new AriesFrameworkException(ErrorCode.NoPublicDid);
+                connectionRecord.MyVk = provisioning.IssuerVerkey ?? throw new AriesFrameworkException(ErrorCode.NoPublicDid);
+            } 
+            else
+            {
+                var myDid = await Did.CreateAndStoreMyDidAsync(agentContext.Wallet, "{}");
+                connectionRecord.MyDid = DidUtils.ConvertVerkeyToDidKey(myDid.VerKey);
+                connectionRecord.MyVk = myDid.VerKey;
+                
+                var provisioningRecord = await _provisioningService.GetProvisioningAsync(agentContext.Wallet);
+                var didDoc = new AttachmentContent
+                    {Base64 = connectionRecord.MyDidDoc(provisioningRecord).ToJson().ToBase64Url()};
+                await didDoc.SignWithJsonWebSignature(agentContext.Wallet, connectionRecord.MyVk);
+            
+                attachment = new Attachment
+                {
+                    Id = Guid.NewGuid().ToString(),
+                    MimeType = "application/json",
+                    Data = didDoc
+                };
+            }
 
             var response = new DidExchangeResponseMessage
             {
@@ -166,6 +279,7 @@ namespace Hyperledger.Aries.Features.Handshakes.DidExchange
                 Did = connectionRecord.MyDid,
                 DidDoc = attachment
             };
+            response.ThreadFrom(connectionRecord.GetTag(TagConstants.LastThreadId), connectionRecord.GetTag(TagConstants.ParentThreadId));
             await _recordService.UpdateAsync(agentContext.Wallet, connectionRecord);
 
             return (response, connectionRecord);
@@ -177,7 +291,7 @@ namespace Hyperledger.Aries.Features.Handshakes.DidExchange
             await connectionRecord.TriggerAsync(ConnectionTrigger.Response);
             
             DidDoc didDoc = null;
-            if (responseMessage.DidDoc.Data.Base64 is { } data)
+            if (responseMessage.DidDoc?.Data?.Base64 is { } data)
             {
                 var isValidSignature = await responseMessage.DidDoc.Data.VerifyJsonWebSignature();
                 if (isValidSignature == false)
@@ -186,25 +300,28 @@ namespace Hyperledger.Aries.Features.Handshakes.DidExchange
                 
                 var json = data.FromBase64Url();
                 didDoc = json.ToObject<DidDoc>();
+                
+                if (didDoc.Keys.All(key => key.Type == DidDocExtensions.DefaultKeyType) == false)
+                {
+                    throw new NotImplementedException($"Only {DidDocExtensions.DefaultKeyType} is supported");
+                }
+
+                var indyService = (IndyAgentDidDocService)didDoc.Services.First(service => service is IndyAgentDidDocService);
+
+                var agentEndpoint = new AgentEndpoint(indyService.ServiceEndpoint, null, indyService.RoutingKeys.ToArray());
+
+                connectionRecord.TheirDid = responseMessage.Did;
+                connectionRecord.TheirVk =
+                    didDoc.Keys.FirstOrDefault(key => key.Controller == responseMessage.Did)?.PublicKeyBase58
+                    ?? throw new NullReferenceException("Missing public key for controller");
+                connectionRecord.Endpoint = agentEndpoint;
             }
 
             if (didDoc == null)
-                throw new NotImplementedException("Response message must provide an attached did document");
-
-            if (didDoc.Keys.All(key => key.Type == DidDocExtensions.DefaultKeyType) == false)
             {
-                throw new NotImplementedException($"Only {DidDocExtensions.DefaultKeyType} is supported");
-            }
-
-            var indyService = (IndyAgentDidDocService)didDoc.Services.First(service => service is IndyAgentDidDocService);
-
-            var agentEndpoint = new AgentEndpoint(indyService.ServiceEndpoint, null, indyService.RoutingKeys.ToArray());
-
-            connectionRecord.TheirDid = responseMessage.Did;
-            connectionRecord.TheirVk =
-                didDoc.Keys.FirstOrDefault(key => key.Controller == responseMessage.Did)?.PublicKeyBase58
-                ?? throw new NullReferenceException("Missing public key for controller");
-            connectionRecord.Endpoint = agentEndpoint;
+                if (responseMessage.Did != connectionRecord.TheirDid)
+                    throw new NotImplementedException("Resolvable Dids cannot be replaced.");
+            };
 
             await _recordService.UpdateAsync(agentContext.Wallet, connectionRecord);
             
@@ -228,6 +345,7 @@ namespace Hyperledger.Aries.Features.Handshakes.DidExchange
             {
                 Id = Guid.NewGuid().ToString()
             };
+            completeMessage.ThreadFrom(connectionRecord.GetTag(TagConstants.LastThreadId), connectionRecord.GetTag(TagConstants.ParentThreadId));
 
             return (completeMessage, connectionRecord);
         }

--- a/src/Hyperledger.Aries/Features/Handshakes/DidExchange/IDidExchangeService.cs
+++ b/src/Hyperledger.Aries/Features/Handshakes/DidExchange/IDidExchangeService.cs
@@ -2,6 +2,7 @@ using System.Threading.Tasks;
 using Hyperledger.Aries.Agents;
 using Hyperledger.Aries.Features.Handshakes.Common;
 using Hyperledger.Aries.Features.Handshakes.DidExchange.Models;
+using Hyperledger.Aries.Features.OutOfBand;
 
 namespace Hyperledger.Aries.Features.Handshakes.DidExchange
 {
@@ -14,9 +15,9 @@ namespace Hyperledger.Aries.Features.Handshakes.DidExchange
         /// Not implemented yet
         /// </summary>
         /// <param name="agentContext">The agent context.</param>
-        /// <param name="message">The invitation message.</param>
+        /// <param name="invitation">The invitation message.</param>
         /// <returns>The did exchange request message</returns>
-        Task<(DidExchangeRequestMessage, ConnectionRecord)> CreateRequestAsync(IAgentContext agentContext, AgentMessage message);
+        Task<ConnectionRecord> ProcessInvitationAsync(IAgentContext agentContext, InvitationMessage invitation);
         
         /// <summary>
         /// Create did exchange request based on a public resolvable did.
@@ -25,14 +26,23 @@ namespace Hyperledger.Aries.Features.Handshakes.DidExchange
         /// <param name="did">A public resolvable did.</param>
         /// <returns>The did exchange request message</returns>
         Task<(DidExchangeRequestMessage, ConnectionRecord)> CreateRequestAsync(IAgentContext agentContext, string did);
+        
+        /// <summary>
+        /// Create did exchange request based on a public resolvable did.
+        /// </summary>
+        /// <param name="agentContext">The agent context.</param>
+        /// <param name="record">An existent connection record.</param>
+        /// <returns>The did exchange request message</returns>
+        Task<(DidExchangeRequestMessage, ConnectionRecord)> CreateRequestAsync(IAgentContext agentContext, ConnectionRecord record);
 
         /// <summary>
         /// Process a did exchange request message.
         /// </summary>
         /// <param name="agentContext">The agent context.</param>
         /// <param name="requestMessage">The did exchange request message.</param>
+        /// <param name="record">The connection record if request was based on an invitation.</param>
         /// <returns>The connection record.</returns>
-        Task<ConnectionRecord> ProcessRequestAsync(IAgentContext agentContext, DidExchangeRequestMessage requestMessage);
+        Task<ConnectionRecord> ProcessRequestAsync(IAgentContext agentContext, DidExchangeRequestMessage requestMessage, ConnectionRecord record = null);
 
         /// <summary>
         /// Create did exchange response message. 

--- a/src/Hyperledger.Aries/Features/OutOfBand/DefaultOutOfBandHandler.cs
+++ b/src/Hyperledger.Aries/Features/OutOfBand/DefaultOutOfBandHandler.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Hyperledger.Aries.Agents;
+
+namespace Hyperledger.Aries.Features.OutOfBand
+{
+    public class DefaultOutOfBandHandler : IMessageHandler
+    {
+        private readonly IOutOfBandService _outOfBandService;
+
+        public DefaultOutOfBandHandler(IOutOfBandService outOfBandService)
+        {
+            _outOfBandService = outOfBandService;
+        }
+
+        public IEnumerable<MessageType> SupportedMessageTypes => new MessageType[]
+        {
+            MessageTypesHttps.OutOfBand.Invitation,
+            MessageTypesHttps.OutOfBand.HandshakeReuse,
+            MessageTypesHttps.OutOfBand.HandshakeReuseAccepted,
+            MessageTypesHttps.OutOfBand.ProblemReport
+        };
+        
+        public async Task<AgentMessage> ProcessAsync(IAgentContext agentContext, UnpackedMessageContext messageContext)
+        {
+            switch (messageContext.GetMessageType())
+            {
+                case MessageTypesHttps.OutOfBand.HandshakeReuse:
+                    var reuseMessage = messageContext.GetMessage<HandshakeReuseMessage>();
+                    var msg = await _outOfBandService.ProcessHandshakeReuseMessage(agentContext, reuseMessage);
+                    
+                    return msg;
+                
+                case MessageTypesHttps.OutOfBand.HandshakeReuseAccepted:
+                    var reuseAccepted = messageContext.GetMessage<HandshakeReuseAcceptedMessage>();
+                    await _outOfBandService.ProcessHandshakeReuseAccepted(agentContext, reuseAccepted);
+                    return null;
+                
+                case MessageTypesHttps.OutOfBand.ProblemReport:
+                    throw new NotImplementedException();
+
+                default:
+                    throw new AriesFrameworkException(ErrorCode.InvalidMessage,
+                        $"Unsupported message type {messageContext.GetMessageType()}");
+            }
+        }
+    }
+}

--- a/src/Hyperledger.Aries/Features/OutOfBand/DefaultOutOfBandService.cs
+++ b/src/Hyperledger.Aries/Features/OutOfBand/DefaultOutOfBandService.cs
@@ -38,7 +38,7 @@ namespace Hyperledger.Aries.Features.OutOfBand
         }
 
         /// <inheritdoc />
-        public async Task<(InvitationMessage, ConnectionRecord)> CreateInvitationAsync(IAgentContext agentContext, IEnumerable<AgentMessage> requests = null, InviteConfiguration config = null)
+        public virtual async Task<(InvitationMessage, ConnectionRecord)> CreateInvitationAsync(IAgentContext agentContext, IEnumerable<AgentMessage> requests = null, InviteConfiguration config = null)
         {
             config ??= new InviteConfiguration();
             var (_, record) = await _connectionService.CreateInvitationAsync(agentContext, config);
@@ -75,7 +75,7 @@ namespace Hyperledger.Aries.Features.OutOfBand
         }
 
         /// <inheritdoc />
-        public async Task<(HandshakeReuseMessage, ConnectionRecord)> ProcessInvitationMessage(IAgentContext agentContext, InvitationMessage invitation)
+        public virtual async Task<(HandshakeReuseMessage, ConnectionRecord)> ProcessInvitationMessage(IAgentContext agentContext, InvitationMessage invitation)
         {
             if (invitation.Accept.Contains("didcomm/aip2;env=rfc19") == false)
                 throw new NotImplementedException("The agent only supports encryption envelope v1.");
@@ -127,7 +127,7 @@ namespace Hyperledger.Aries.Features.OutOfBand
         }
 
         /// <inheritdoc />
-        public async Task<HandshakeReuseAcceptedMessage> ProcessHandshakeReuseMessage(IAgentContext agentContext, HandshakeReuseMessage handshakeReuseMessage)
+        public virtual Task<HandshakeReuseAcceptedMessage> ProcessHandshakeReuseMessage(IAgentContext agentContext, HandshakeReuseMessage handshakeReuseMessage)
         {
             var accept = new HandshakeReuseAcceptedMessage();
             accept.ThreadFrom(handshakeReuseMessage);
@@ -138,11 +138,11 @@ namespace Hyperledger.Aries.Features.OutOfBand
                 ThreadId = handshakeReuseMessage.GetThreadId()
             });
 
-            return accept;
+            return Task.FromResult(accept);
         }
 
         /// <inheritdoc />
-        public Task ProcessHandshakeReuseAccepted(IAgentContext agentContext,
+        public virtual Task ProcessHandshakeReuseAccepted(IAgentContext agentContext,
             HandshakeReuseAcceptedMessage handshakeReuseAcceptedMessage)
         {
             _eventAggregator.Publish(new ServiceMessageProcessingEvent

--- a/src/Hyperledger.Aries/Features/OutOfBand/DefaultOutOfBandService.cs
+++ b/src/Hyperledger.Aries/Features/OutOfBand/DefaultOutOfBandService.cs
@@ -1,0 +1,190 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Hyperledger.Aries.Agents;
+using Hyperledger.Aries.Common;
+using Hyperledger.Aries.Configuration;
+using Hyperledger.Aries.Contracts;
+using Hyperledger.Aries.Decorators.Threading;
+using Hyperledger.Aries.Features.Handshakes;
+using Hyperledger.Aries.Features.Handshakes.Common;
+using Hyperledger.Aries.Features.Handshakes.Common.Dids;
+using Hyperledger.Aries.Features.Handshakes.Connection;
+using Hyperledger.Aries.Features.Handshakes.Connection.Models;
+using Hyperledger.Aries.Features.Handshakes.DidExchange;
+using Hyperledger.Aries.Models.Events;
+using Hyperledger.Aries.Storage;
+using Hyperledger.Aries.Utils;
+
+namespace Hyperledger.Aries.Features.OutOfBand
+{
+    /// <inheritdoc />
+    public class DefaultOutOfBandService : IOutOfBandService
+    {
+        private IEventAggregator _eventAggregator;
+        private IConnectionService _connectionService;
+        private IDidExchangeService _didExchangeService;
+        private IProvisioningService _provisioningService;
+        private IWalletRecordService _recordService;
+
+        public DefaultOutOfBandService(IEventAggregator eventAggregator, IConnectionService connectionService, IProvisioningService provisioningService, IDidExchangeService didExchangeService, IWalletRecordService recordService)
+        {
+            _eventAggregator = eventAggregator;
+            _connectionService = connectionService;
+            _provisioningService = provisioningService;
+            _didExchangeService = didExchangeService;
+            _recordService = recordService;
+        }
+
+        /// <inheritdoc />
+        public async Task<(InvitationMessage, ConnectionRecord)> CreateInvitationAsync(IAgentContext agentContext, IEnumerable<AgentMessage> requests = null, InviteConfiguration config = null)
+        {
+            config ??= new InviteConfiguration();
+            var (_, record) = await _connectionService.CreateInvitationAsync(agentContext, config);
+            var provisioningRecord = await _provisioningService.GetProvisioningAsync(agentContext.Wallet);
+            
+            var invitation = new InvitationMessage
+            {
+                Label = config.MyAlias.Name ?? provisioningRecord.Owner.Name ?? string.Empty,
+                GoalCode = string.Empty,
+                Goal = string.Empty,
+                Accept = new []{ MediaTypes.EncryptionEnvelopeV1 },
+                HandshakeProtocols = new []{ HandshakeProtocolUri.DidExchange, HandshakeProtocolUri.Connections }
+            };
+            
+            if (config.UsePublicDid)
+            {
+                if (provisioningRecord.IssuerDid == null)
+                    throw new AriesFrameworkException(ErrorCode.NoPublicDid, "No public did was provisioned.");
+                invitation.Services = new object[] { DidUtils.ToDid(DidUtils.DidSovMethodSpec, provisioningRecord.IssuerDid) };
+                record.SetTag(TagConstants.UsePublicDid, "true");
+            }
+            else
+            {
+                invitation.Services = new object[] {record.MyDidCommService(provisioningRecord)};
+            }
+            invitation.AddRequests(requests);
+
+            var parentThreadId = invitation.GetThreadId();
+            record.SetTag(TagConstants.ParentThreadId, parentThreadId);
+            
+            await _recordService.UpdateAsync(agentContext.Wallet, record);
+
+            return (invitation, record);
+        }
+
+        /// <inheritdoc />
+        public async Task<(HandshakeReuseMessage, ConnectionRecord)> ProcessInvitationMessage(IAgentContext agentContext, InvitationMessage invitation)
+        {
+            if (invitation.Accept.Contains("didcomm/aip2;env=rfc19") == false)
+                throw new NotImplementedException("The agent only supports encryption envelope v1.");
+            
+            ConnectionRecord connectionRecord = null;
+            HandshakeReuseMessage reuseMessage = null;
+            
+            var service = invitation.Services.First();
+            string theirDid = null; 
+            if (service is string resolvableDid)
+            {
+                theirDid = resolvableDid;
+            }
+            if (service is DidCommServiceEndpoint didComm)
+            {
+                theirDid = didComm.RecipientKeys.FirstOrDefault();
+            }
+            theirDid = DidUtils.EnsureQualifiedDid(theirDid);
+            
+            var existingConnection = (await _connectionService.ListAsync(agentContext,
+                SearchQuery.Equal(nameof(ConnectionRecord.TheirDid), theirDid))).FirstOrDefault();
+            
+            if (existingConnection != null && invitation.AttachedRequests == null)
+            {
+                var message = new HandshakeReuseMessage
+                {
+                    Id = invitation.Id
+                };
+                message.ThreadFrom(message.Id, invitation.Id);
+
+                reuseMessage = message;
+                connectionRecord = existingConnection;
+            } 
+            else if (invitation.HandshakeProtocols != null && invitation.HandshakeProtocols.Length > 0)
+            {
+                connectionRecord = await InitiateHandshakeProtocol(agentContext, invitation);
+            }
+            
+            // Todo: Handle attached requests
+
+            _eventAggregator.Publish(new ServiceMessageProcessingEvent()
+            {
+                MessageType = invitation.Type,
+                RecordId = connectionRecord?.Id,
+                ThreadId = invitation.GetThreadId()
+            });
+
+            return (reuseMessage, connectionRecord);
+        }
+
+        /// <inheritdoc />
+        public async Task<HandshakeReuseAcceptedMessage> ProcessHandshakeReuseMessage(IAgentContext agentContext, HandshakeReuseMessage handshakeReuseMessage)
+        {
+            var accept = new HandshakeReuseAcceptedMessage();
+            accept.ThreadFrom(handshakeReuseMessage);
+            
+            _eventAggregator.Publish(new ServiceMessageProcessingEvent
+            {
+                MessageType = handshakeReuseMessage.Type,
+                ThreadId = handshakeReuseMessage.GetThreadId()
+            });
+
+            return accept;
+        }
+
+        /// <inheritdoc />
+        public Task ProcessHandshakeReuseAccepted(IAgentContext agentContext,
+            HandshakeReuseAcceptedMessage handshakeReuseAcceptedMessage)
+        {
+            _eventAggregator.Publish(new ServiceMessageProcessingEvent
+            {
+                MessageType = handshakeReuseAcceptedMessage.Type,
+                ThreadId = handshakeReuseAcceptedMessage.GetThreadId()
+            });
+
+            return Task.CompletedTask;
+        }
+
+        private Task<ConnectionRecord> InitiateHandshakeProtocol(IAgentContext agentContext, InvitationMessage invitation)
+        {
+            HandshakeProtocol? selectedHandshake =
+                GetFirstSupportedHandshakeProtocol(invitation.HandshakeProtocols);
+            
+            switch (selectedHandshake)
+            {
+                case HandshakeProtocol.Connections:
+                    return _connectionService.ProcessInvitationAsync(agentContext, invitation);
+                case HandshakeProtocol.DidExchange:
+                    return _didExchangeService.ProcessInvitationAsync(agentContext, invitation);
+                default:
+                    throw new AriesFrameworkException(ErrorCode.InvalidMessage,
+                        "Unsupported handshake protocol in out-of-band message");
+            }
+        }
+
+        private HandshakeProtocol? GetFirstSupportedHandshakeProtocol(string[] handshakes)
+        {
+            foreach (var handshakeProtocol in handshakes)
+            {
+                switch (handshakeProtocol)
+                {
+                    case HandshakeProtocolUri.Connections:
+                        return HandshakeProtocol.Connections;
+                    case HandshakeProtocolUri.DidExchange:
+                        return HandshakeProtocol.DidExchange;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Hyperledger.Aries/Features/OutOfBand/HandshakeReuseAcceptedMessage.cs
+++ b/src/Hyperledger.Aries/Features/OutOfBand/HandshakeReuseAcceptedMessage.cs
@@ -1,0 +1,15 @@
+using System;
+using Hyperledger.Aries.Agents;
+
+namespace Hyperledger.Aries.Features.OutOfBand
+{
+    public class HandshakeReuseAcceptedMessage : AgentMessage
+    {
+        public HandshakeReuseAcceptedMessage()
+        {
+            Id = Guid.NewGuid().ToString();
+            Type = MessageTypesHttps.OutOfBand.HandshakeReuse;
+            UseMessageTypesHttps = true;
+        }
+    }
+}

--- a/src/Hyperledger.Aries/Features/OutOfBand/HandshakeReuseMessage.cs
+++ b/src/Hyperledger.Aries/Features/OutOfBand/HandshakeReuseMessage.cs
@@ -1,0 +1,15 @@
+using System;
+using Hyperledger.Aries.Agents;
+
+namespace Hyperledger.Aries.Features.OutOfBand
+{
+    public class HandshakeReuseMessage : AgentMessage
+    {
+        public HandshakeReuseMessage()
+        {
+            Id = Guid.NewGuid().ToString();
+            Type = MessageTypesHttps.OutOfBand.HandshakeReuse;
+            UseMessageTypesHttps = true;
+        }
+    }
+}

--- a/src/Hyperledger.Aries/Features/OutOfBand/IOutOfBandService.cs
+++ b/src/Hyperledger.Aries/Features/OutOfBand/IOutOfBandService.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Hyperledger.Aries.Agents;
+using Hyperledger.Aries.Features.Handshakes.Common;
+using Hyperledger.Aries.Features.Handshakes.Connection.Models;
+
+namespace Hyperledger.Aries.Features.OutOfBand
+{
+    /// <summary>
+    /// Out-of-band service 
+    /// </summary>
+    public interface IOutOfBandService
+    {
+        /// <summary>
+        /// Create an out-of-band invitation and an associated ConnectionRecord
+        /// </summary>
+        /// <param name="agentContext">The agent context.</param>
+        /// <param name="requests">An enumerable of requests to attach.</param>
+        /// <param name="config">A configuration for the invite.</param>
+        /// <returns></returns>
+        Task<(InvitationMessage, ConnectionRecord)> CreateInvitationAsync(IAgentContext agentContext, IEnumerable<AgentMessage> requests = null, InviteConfiguration config = null);
+
+        /// <summary>
+        /// Process an out-of-band invitation message
+        /// </summary>
+        /// <param name="agentContext">The agent context.</param>
+        /// <param name="invitation">The invitation.</param>
+        /// <returns>A <see cref="HandshakeReuseAcceptedMessage"/> if there is an existing connection for the given DID
+        /// and the according <see cref="ConnectionRecord"/>. Otherwise it will only return a new <see cref="ConnectionRecord"/>.</returns>
+        Task<(HandshakeReuseMessage, ConnectionRecord)> ProcessInvitationMessage(IAgentContext agentContext, InvitationMessage invitation);
+
+        /// <summary>
+        /// Process a HandshakeReuseMessage 
+        /// </summary>
+        /// <param name="agentContext">The agent context.</param>
+        /// <param name="handshakeReuseMessage">The message.</param>
+        /// <returns><see cref="HandshakeReuseAcceptedMessage"/></returns>
+        Task<HandshakeReuseAcceptedMessage> ProcessHandshakeReuseMessage(IAgentContext agentContext, HandshakeReuseMessage handshakeReuseMessage);
+
+        /// <summary>
+        /// Process a HandshakeReuseAcceptedMessage
+        /// </summary>
+        /// <param name="agentContext">The agent context.</param>
+        /// <param name="handshakeReuseAcceptedMessage">The agent context.</param>
+        /// <returns></returns>
+        Task ProcessHandshakeReuseAccepted(IAgentContext agentContext, HandshakeReuseAcceptedMessage handshakeReuseAcceptedMessage);
+    }
+}

--- a/src/Hyperledger.Aries/Features/OutOfBand/InvitationMessage.cs
+++ b/src/Hyperledger.Aries/Features/OutOfBand/InvitationMessage.cs
@@ -1,0 +1,65 @@
+using System;
+using Hyperledger.Aries.Agents;
+using Hyperledger.Aries.Decorators.Attachments;
+using Newtonsoft.Json;
+
+namespace Hyperledger.Aries.Features.OutOfBand
+{
+    /// <summary>
+    /// Invitation message defined by Aries RFC-0434
+    /// </summary>
+    public class InvitationMessage : AgentMessage
+    {
+        /// <summary>
+        /// Initialise a new instance of <see cref="InvitationMessage"/>
+        /// </summary>
+        public InvitationMessage()
+        {
+            Id = Guid.NewGuid().ToString().ToLowerInvariant();
+            Type = MessageTypesHttps.OutOfBand.Invitation;
+            UseMessageTypesHttps = true;
+        }
+        
+        /// <summary>
+        /// A self-attested string that the sender may want to display to the user
+        /// </summary>
+        [JsonProperty("label", NullValueHandling = NullValueHandling.Ignore)]
+        public string Label { get; set; }
+        
+        /// <summary>
+        /// A self-attested code the sender may want to display to the user
+        /// </summary>
+        [JsonProperty("goal_code", NullValueHandling = NullValueHandling.Ignore)]
+        public string GoalCode { get; set; }
+        
+        /// <summary>
+        /// A self-attested string that the sender may want to display to the user about the context-specific goal of the out-of-band message
+        /// </summary>
+        [JsonProperty("goal", NullValueHandling = NullValueHandling.Ignore)]
+        public string Goal { get; set; }
+        
+        /// <summary>
+        /// An array of media (aka mime) types in the order of preference of the sender that the receiver can use in responding to the message
+        /// </summary>
+        [JsonProperty("accept", NullValueHandling = NullValueHandling.Ignore)]
+        public string[] Accept { get; set; }
+        
+        /// <summary>
+        /// An array of protocols in the order of preference of the sender that the receiver can use in responding to the message in order to create or reuse a connection with the sender
+        /// </summary>
+        [JsonProperty("handshake_protocols", NullValueHandling = NullValueHandling.Ignore)]
+        public string[] HandshakeProtocols { get; set; }
+        
+        /// <summary>
+        /// An attachment decorator containing an array of request messages in order of preference that the receiver can using in responding to the message
+        /// </summary>
+        [JsonProperty("requests~attach", NullValueHandling = NullValueHandling.Ignore)]
+        public Attachment[] AttachedRequests { get; set; }
+        
+        /// <summary>
+        /// An array of union types that the receiver uses when responding to the message - either service object or a DID
+        /// </summary>
+        [JsonProperty("services")]
+        public object[] Services { get; set; }
+    }
+}

--- a/src/Hyperledger.Aries/Features/OutOfBand/InvitationMessageExtensions.cs
+++ b/src/Hyperledger.Aries/Features/OutOfBand/InvitationMessageExtensions.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using Hyperledger.Aries.Agents;
+using Hyperledger.Aries.Decorators.Attachments;
+using Hyperledger.Aries.Extensions;
+
+namespace Hyperledger.Aries.Features.OutOfBand
+{
+    public static class InvitationMessageExtensions
+    {
+        public static void AddRequests(this InvitationMessage message, IEnumerable<AgentMessage> requests)
+        {
+            if (requests == null) return;
+            
+            List<Attachment> attachments = new List<Attachment>();
+            int index = 0;
+            foreach (var request in requests)
+            {
+                attachments.Add(new Attachment
+                {
+                    Id = "request-" + index,
+                    Data = new AttachmentContent
+                    {
+                        Json = request.ToJson()
+                    }
+                });
+            }
+
+            message.AttachedRequests = attachments.ToArray();
+        }
+    }
+}

--- a/src/Hyperledger.Aries/Features/RevocationNotification/RevocationNotificationMessage.cs
+++ b/src/Hyperledger.Aries/Features/RevocationNotification/RevocationNotificationMessage.cs
@@ -25,7 +25,7 @@ namespace Hyperledger.Aries.Features.RevocationNotification
         /// a different credential format but contains the same claims as described here; therefore, this message
         /// notifies the holder that all of these credentials have been revoked.
         /// </summary>
-        /// <value>The thread id</Value>
+        /// <value>The thread id</value>
         public string ThreadId { get; set; }
 
         /// <summary>

--- a/src/Hyperledger.Aries/Utils/DidUtils.cs
+++ b/src/Hyperledger.Aries/Utils/DidUtils.cs
@@ -24,6 +24,16 @@ namespace Hyperledger.Aries.Utils
         public const string DidSovMethodSpec = "sov";
 
         /// <summary>
+        /// Did Key method spec.
+        /// </summary>
+        public const string DidKeyMethodSpec = "key";
+
+        /// <summary>
+        /// Did Indy method spec.
+        /// </summary>
+        public const string DidIndyMethodSpec = "indy";
+
+        /// <summary>
         /// Constructs a DID from a method spec and identifier.
         /// </summary>
         /// <param name="methodSpec">DID method spec.</param>
@@ -44,6 +54,21 @@ namespace Hyperledger.Aries.Utils
                 return null;
             
             return regExMatches[0].Groups[2].Value;
+        }
+
+        /// <summary>
+        /// Extracts the method specification from a DID.
+        /// </summary>
+        /// <param name="did">DID to extract the method spec from.</param>
+        /// <returns></returns>
+        public static string MethodSpecFromDid(string did)
+        {
+            var regExMatches = Regex.Matches(did, DID_REGEX);
+            
+            if (regExMatches.Count != 1 || regExMatches[0].Groups.Count < 3)
+                return null;
+
+            return regExMatches[0].Groups[1].Value;
         }
 
         /// <summary>
@@ -134,6 +159,29 @@ namespace Hyperledger.Aries.Utils
             }
 
             throw new ArgumentException($"Value {didKey} has missing ED25519 multicodec prefix", nameof(didKey));
+        }
+
+        /// <summary>
+        /// Ensure a given string represents a supported DID method.
+        /// Will transform unqualified verkeys into did:key format.
+        /// </summary>
+        /// <param name="didCandidate"></param>
+        /// <returns></returns>
+        /// <exception cref="AriesFrameworkException"></exception>
+        public static string EnsureQualifiedDid(string didCandidate)
+        {
+            if (MethodSpecFromDid(didCandidate) == DidKeyMethodSpec ||
+                MethodSpecFromDid(didCandidate) == DidSovMethodSpec)
+            {
+                return didCandidate;
+            }
+
+            if (IsVerkey(didCandidate))
+            {
+                return ConvertVerkeyToDidKey(didCandidate);
+            }
+            
+            throw new AriesFrameworkException(ErrorCode.UnsupportedDidMethod);
         }
     }
 }

--- a/src/Hyperledger.Aries/Utils/TagConstants.cs
+++ b/src/Hyperledger.Aries/Utils/TagConstants.cs
@@ -17,6 +17,8 @@
 
         public const string IssuerDid = "issuerDid";
 
+        public const string InvitationKey = "InvitationKey";
+
         public const string AutoAcceptConnection = "autoAcceptConnection";
 
         public const string Role = "role";
@@ -28,6 +30,10 @@
         public const string Requestor = "requestor";
         
         public const string LastThreadId = "threadId";
+
+        public const string ParentThreadId = "parentThreadId";
+
+        public const string UsePublicDid = "usePublicDid";
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 
     }

--- a/test/Hyperledger.Aries.Tests/DidCommServiceTests.cs
+++ b/test/Hyperledger.Aries.Tests/DidCommServiceTests.cs
@@ -1,0 +1,90 @@
+using System.Collections.Generic;
+using System.Linq;
+using Hyperledger.Aries.Agents;
+using Hyperledger.Aries.Configuration;
+using Hyperledger.Aries.Extensions;
+using Hyperledger.Aries.Features.Handshakes.Common;
+using Hyperledger.Aries.Features.Handshakes.Common.Dids;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Hyperledger.Aries.Tests
+{
+    public class DidCommServiceTests
+    {
+        [Fact]
+        public void CanDeserializeDidCommServiceEndpoint()
+        {
+            const string service = @"{
+                ""id"": ""did:example:123456789abcdefghi#did-communication"",
+                ""type"": ""did-communication"",
+                ""priority"" : 0,
+                ""recipientKeys"" : [ ""did:example:123456789abcdefghi#1"" ],
+                ""routingKeys"" : [ ""did:example:123456789abcdefghi#1"" ],
+                ""accept"": [
+                    ""didcomm/aip2;env=rfc587"",
+                    ""didcomm/aip2;env=rfc19""
+                ],
+                ""serviceEndpoint"": ""https://agent.example.com/""
+            }";
+
+            var obj = service.ToObject<DidCommServiceEndpoint>();
+            
+            Assert.NotNull(obj);
+            Assert.Equal("did:example:123456789abcdefghi#did-communication", obj.Id);
+            Assert.Equal("did-communication", obj.Type);
+            Assert.Equal(0, obj.Priority);
+            Assert.Equal("did:example:123456789abcdefghi#1", obj.RecipientKeys.First());
+            Assert.Equal("did:example:123456789abcdefghi#1", obj.RoutingKeys.First());
+            Assert.Equal("didcomm/aip2;env=rfc587", obj.Accept.First());
+            Assert.Equal("didcomm/aip2;env=rfc19", obj.Accept.Last());
+            Assert.Equal("https://agent.example.com/", obj.ServiceEndpoint);
+        }
+        
+        [Fact]
+        public void CanSerializeDidCommServiceEndpoint()
+        {
+            var service = new DidCommServiceEndpoint
+            {
+                Id = "did:example:123456789abcdefghi#did-communication",
+                Priority = 0,
+                RecipientKeys = new List<string>() {"did:example:123456789abcdefghi#1"},
+                RoutingKeys = new List<string>() {"did:example:123456789abcdefghi#1"},
+                Accept = new List<string>() {"didcomm/aip2;env=rfc587", "didcomm/aip2;env=rfc19"},
+                ServiceEndpoint = "https://agent.example.com/"
+            };
+
+            var json = service.ToJson();
+            
+            Assert.False(string.IsNullOrEmpty(json));
+
+            var jobj = JObject.Parse(json);
+            
+            Assert.Equal("https://agent.example.com/", jobj["serviceEndpoint"]);
+        }
+
+        [Fact]
+        public void CanDeriveDidCommServiceEndpointFromConnectionAndProvisioningRecord()
+        {
+            var connectionRecord = new ConnectionRecord
+            {
+                MyDid = "did:example:123456789abcdefghi",
+                MyVk = "8HH5gYEeNc3z7PYXmd54d4x6qAfCNrqQqEB3nS7Zfu7K"
+            };
+
+            var provisioningRecord = new ProvisioningRecord
+            {
+                Endpoint = new AgentEndpoint
+                {
+                    Verkey = new []{"did:sov:123456789abcdefghi"}
+                }
+            };
+
+            var result = connectionRecord.MyDidCommService(provisioningRecord);
+            
+            Assert.NotNull(result);
+            Assert.Equal("did:key:z6MkmjY8GnV5i9YTDtPETC2uUAW6ejw3nk5mXF5yci5ab7th", result.RecipientKeys.First());
+            Assert.Equal("did:sov:123456789abcdefghi", result.RoutingKeys.First());
+        }
+    }
+}

--- a/test/Hyperledger.Aries.Tests/Integration/OutOfBandTests.cs
+++ b/test/Hyperledger.Aries.Tests/Integration/OutOfBandTests.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Threading.Tasks;
+using Hyperledger.Aries.Agents;
+using Hyperledger.Aries.Contracts;
+using Hyperledger.Aries.Decorators.Threading;
+using Hyperledger.Aries.Features.Handshakes;
+using Hyperledger.Aries.Features.Handshakes.Common;
+using Hyperledger.Aries.Features.Handshakes.Connection.Models;
+using Hyperledger.Aries.Features.OutOfBand;
+using Hyperledger.Aries.Storage;
+using Hyperledger.Aries.TestHarness;
+using Hyperledger.TestHarness;
+using Hyperledger.TestHarness.Mock;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Hyperledger.Aries.Tests.Integration
+{
+    public class OutOfBandTests : IAsyncLifetime
+    {
+        WalletConfiguration config1 = new WalletConfiguration { Id = Guid.NewGuid().ToString() };
+        WalletConfiguration config2 = new WalletConfiguration { Id = Guid.NewGuid().ToString() };
+        WalletCredentials cred = new WalletCredentials { Key = "2" };
+
+        private MockAgent _sender;
+        private MockAgent _receiver;
+        private readonly MockAgentRouter _router = new MockAgentRouter();
+        
+        public async Task InitializeAsync()
+        {
+            _sender = await MockUtils.CreateAsync("sender", config1, cred, new MockAgentHttpHandler((cb) => _router.RouteMessage(cb.name, cb.data)), TestConstants.StewardSeed);
+            _router.RegisterAgent(_sender);
+            _receiver = await MockUtils.CreateAsync("receiver", config2, cred, new MockAgentHttpHandler((cb) => _router.RouteMessage(cb.name, cb.data)));
+            _router.RegisterAgent(_receiver);
+            
+            var ledgerService = _sender.ServiceProvider.GetRequiredService<ILedgerService>();
+            await ledgerService.RegisterServiceEndpointAsync(_sender.Context, TestConstants.StewardDid,
+                "http://sender");
+        }
+
+        [Fact]
+        public async Task CanDoHandshakeIfNotConnected()
+        {
+            var (receiverRecord, senderRecord) = await AgentScenarios.ExchangeDidsWithPrivateDids(_receiver, _sender); 
+            
+            Assert.NotNull(receiverRecord);
+            Assert.NotNull(senderRecord);
+            Assert.Equal(ConnectionState.Connected, receiverRecord.State);
+            Assert.Equal(ConnectionState.Connected, senderRecord.State);
+        }
+
+        [Fact]
+        public Task CanAnswerRequestWithoutConnection()
+        {
+            return Task.CompletedTask;
+        }
+
+        [Fact]
+        public Task CanAnswerRequestAfterCreatingNewConnection()
+        {
+            return Task.CompletedTask;
+        }
+        
+        [Fact]
+        public Task CanAnswerRequestWithExistingConnection()
+        {
+            return Task.CompletedTask;
+        }
+
+        [Fact]
+        public async Task CanReuseHandshakeIfAlreadyConnected()
+        {
+            var outOfBandService = _sender.GetService<IOutOfBandService>();
+            var messageService = _receiver.GetService<IMessageService>();
+
+            var (receiverRecord, senderRecord) = await AgentScenarios.ExchangeDidsWithPublicDid(_receiver, _sender);
+
+            var (invitation, _) = await outOfBandService.CreateInvitationAsync(_sender.Context, null, new InviteConfiguration {UsePublicDid = true});
+            
+            var (msg, record) = await outOfBandService.ProcessInvitationMessage(_receiver.Context, invitation);
+            
+            Assert.NotNull(msg);
+            Assert.NotNull(record);
+            Assert.Equal(HandshakeProtocol.DidExchange, record.HandshakeProtocol);
+            Assert.Equal(ConnectionState.Connected, record.State);
+            Assert.Equal(msg.Id, msg.GetThreadId());
+            Assert.Equal(invitation.GetThreadId(), msg.GetParentThreadId());
+
+            var reuseAcceptedMessage = await messageService.SendReceiveAsync<HandshakeReuseAcceptedMessage>(_receiver.Context, msg, record);
+
+            Assert.NotNull(reuseAcceptedMessage);
+            Assert.Equal(msg.GetThreadId(), reuseAcceptedMessage.GetThreadId());
+            Assert.Equal(invitation.Id, reuseAcceptedMessage.GetParentThreadId());
+            
+            await outOfBandService.ProcessHandshakeReuseAccepted(_receiver.Context, reuseAcceptedMessage);
+        }
+
+        public async Task DisposeAsync()
+        {
+            await _sender.Dispose();
+            await _receiver.Dispose();
+        }
+    }
+}

--- a/test/Hyperledger.Aries.Tests/MockExtendedConnectionService.cs
+++ b/test/Hyperledger.Aries.Tests/MockExtendedConnectionService.cs
@@ -5,6 +5,7 @@ using Hyperledger.Aries.Common;
 using Hyperledger.Aries.Features.Handshakes.Common;
 using Hyperledger.Aries.Features.Handshakes.Connection;
 using Hyperledger.Aries.Features.Handshakes.Connection.Models;
+using Hyperledger.Aries.Features.OutOfBand;
 using Hyperledger.Aries.Storage;
 
 namespace Hyperledger.Aries.Tests
@@ -32,6 +33,11 @@ namespace Hyperledger.Aries.Tests
         }
 
         public async Task<ConnectionRecord> ProcessInvitationAsync(IAgentContext agentContext, ConnectionInvitationMessage offer)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public async Task<ConnectionRecord> ProcessInvitationAsync(IAgentContext agentContext, InvitationMessage invitation)
         {
             throw new System.NotImplementedException();
         }

--- a/test/Hyperledger.Aries.Tests/Protocols/DidExchangeTests.cs
+++ b/test/Hyperledger.Aries.Tests/Protocols/DidExchangeTests.cs
@@ -67,7 +67,7 @@ namespace Hyperledger.Aries.Tests.Protocols
         {
             var (request, _) = await _didExchangeService.CreateRequestAsync(_requester, TestConstants.StewardDid);
             
-            var responderRecord = await _didExchangeService.ProcessRequestAsync(_responder, request);
+            var responderRecord = await _didExchangeService.ProcessRequestAsync(_responder, request, null);
 
             var (response, record) = await _didExchangeService.CreateResponseAsync(_responder, responderRecord);
             

--- a/test/Hyperledger.Aries.Tests/Protocols/OutOfBandTests.cs
+++ b/test/Hyperledger.Aries.Tests/Protocols/OutOfBandTests.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Hyperledger.Aries.Agents;
+using Hyperledger.Aries.Contracts;
+using Hyperledger.Aries.Extensions;
+using Hyperledger.Aries.Features.Handshakes;
+using Hyperledger.Aries.Features.Handshakes.Connection;
+using Hyperledger.Aries.Features.Handshakes.DidExchange;
+using Hyperledger.Aries.Features.OutOfBand;
+using Hyperledger.Aries.Models.Events;
+using Hyperledger.Aries.Storage;
+using Hyperledger.Indy.WalletApi;
+using Hyperledger.TestHarness.Utils;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Hyperledger.Aries.Tests.Protocols
+{
+    public class OutOfBandTests : IAsyncLifetime
+    {
+        private readonly string _senderConfig = $"{{\"id\":\"{Guid.NewGuid()}\"}}";
+        private readonly string _receiverConfig = $"{{\"id\":\"{Guid.NewGuid()}\"}}";
+        private const string Credentials = "{\"key\":\"test_wallet_key\"}";
+        
+        private IAgentContext _sender;
+        private IAgentContext _receiver;
+
+        private readonly IOutOfBandService _outOfBandService;
+        private readonly Mock<IEventAggregator> _eventAggregator;
+
+        public OutOfBandTests()
+        {
+            _eventAggregator = new Mock<IEventAggregator>();
+            var provisioningService = ServiceUtils.GetDefaultMockProvisioningService();
+            var connectionService = new DefaultConnectionService(_eventAggregator.Object,
+                new DefaultWalletRecordService(), provisioningService,
+                new Mock<ILogger<DefaultConnectionService>>().Object);
+            var didExchangeService = new DefaultDidExchangeService(new Mock<ILedgerService>().Object,
+                new DefaultWalletRecordService(), provisioningService, _eventAggregator.Object);
+                
+            _outOfBandService = new DefaultOutOfBandService(_eventAggregator.Object, connectionService, provisioningService, didExchangeService, new DefaultWalletRecordService());
+        }
+        
+        public async Task InitializeAsync()
+        {
+            _sender = await AgentUtils.Create(_senderConfig, Credentials);
+            _receiver = await AgentUtils.Create(_receiverConfig, Credentials);
+        }
+
+        [Fact]
+        public void CanDeserializeInvitationWithoutRequests()
+        {
+            const string invitationJson = 
+            @"{
+                ""@type"": ""https://didcomm.org/out-of-band/1.1/invitation"",
+                ""@id"": ""98765"",
+                ""label"": ""Faber College"",
+                ""handshake_protocols"": [""https://didcomm.org/didexchange/1.0""],
+                ""services"": [
+                    {
+                        ""id"": ""#inline"",
+                        ""type"": ""did-communication"",
+                        ""recipientKeys"": [""did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH""],
+                        ""routingKeys"": [],
+                        ""serviceEndpoint"": ""https://example.com:5000""
+                    },
+                    ""did:sov:LjgpST2rjsoxYegQDRm7EL""
+                ]
+            }";
+            
+            var invitation = invitationJson.ToObject<InvitationMessage>();
+            
+            Assert.NotNull(invitation);
+            Assert.Null(invitation.AttachedRequests);
+            Assert.Equal("98765", invitation.Id);
+            Assert.Equal("Faber College", invitation.Label);
+            Assert.Equal(HandshakeProtocolUri.DidExchange, invitation.HandshakeProtocols.First());
+            Assert.Null(invitation.GoalCode);
+            Assert.Null(invitation.Goal);
+            Assert.Null(invitation.Accept);
+            Assert.Null(invitation.AttachedRequests);
+            Assert.Equal("did:sov:LjgpST2rjsoxYegQDRm7EL", invitation.Services[1]);
+        }
+
+        [Fact]
+        public void CanDeserializeInvitationWithRequest()
+        {
+            const string invitationJson = 
+            @"{
+                ""@type"": ""https://didcomm.org/out-of-band/1.1/invitation"",
+                ""@id"": ""12345"",
+                ""label"": ""Faber College"",
+                ""goal_code"": ""issue-vc"",
+                ""goal"": ""To issue a Faber College Graduate credential"",
+                ""accept"": [
+                    ""didcomm/aip2;env=rfc587"",
+                    ""didcomm/aip2;env=rfc19""
+                ],
+                ""handshake_protocols"": [
+                    ""https://didcomm.org/didexchange/1.0"",
+                    ""https://didcomm.org/connections/1.0""
+                ],
+                ""requests~attach"": [
+                    {
+                        ""@id"": ""request-0"",
+                        ""mime-type"": ""application/json"",
+                        ""data"": {
+                            ""json"": ""{}""
+                        }
+                    }
+                ],
+                ""services"": [""did:sov:LjgpST2rjsoxYegQDRm7EL""]
+            }";
+            
+            var invitation = invitationJson.ToObject<InvitationMessage>();
+            
+            Assert.NotNull(invitation);
+            Assert.NotNull(invitation.AttachedRequests);
+            Assert.Equal("12345", invitation.Id);
+            Assert.Equal("Faber College", invitation.Label);
+            Assert.Equal("issue-vc", invitation.GoalCode);
+            Assert.Equal("To issue a Faber College Graduate credential", invitation.Goal);
+            Assert.Equal("didcomm/aip2;env=rfc19", invitation.Accept.Last());
+            Assert.Equal("request-0", invitation.AttachedRequests.First().Id);
+            Assert.Equal("did:sov:LjgpST2rjsoxYegQDRm7EL", invitation.Services.First());
+        }
+
+        [Fact]
+        public async Task CanCreateInvitation()
+        {
+            var (invitation, record) = await _outOfBandService.CreateInvitationAsync(_sender, null);
+            
+            Assert.NotNull(invitation);
+            Assert.Null(invitation.AttachedRequests);
+        }
+        
+        [Fact]
+        public async Task CanCreateInvitationWithRequest()
+        {
+            var result = await _outOfBandService.CreateInvitationAsync(_sender, null);
+            
+            Assert.NotNull(result.Item1);
+            Assert.NotNull(result.Item2);
+        }
+
+        [Fact]
+        public async Task CanProcessInvitation()
+        {
+            var (invitation, record) = await _outOfBandService.CreateInvitationAsync(_sender);
+
+            await _outOfBandService.ProcessInvitationMessage(_receiver, invitation);
+
+            _eventAggregator.Verify( x => x.Publish(It.IsAny<ServiceMessageProcessingEvent>()), Times.Once);
+        }
+
+        public async Task DisposeAsync()
+        {
+            if (_sender != null) await _sender.Wallet.CloseAsync();
+            if (_receiver != null) await _receiver.Wallet.CloseAsync();
+
+            await Wallet.DeleteWalletAsync(_senderConfig, Credentials);
+            await Wallet.DeleteWalletAsync(_receiverConfig, Credentials);
+        }
+    }
+}


### PR DESCRIPTION
Signed-off-by: Sebastian Bickerle <sebastian.bickerle@main-incubator.com>

#### Short description of what this resolves:
This adds initial support for the out-of-band protocol. This should enable agents to process out-of-band invitations with handshake protocols and enables the usage of the DidExchange protocol with out-of-band invitations.

#### Changes proposed in this pull request:
- Add DefaultOutOfBandService and OutOfBandHandler to process OutOfBand messages
