### PR TITLE
Add virtual modifier to all public methods of default services

### DIFF
--- a/src/Hyperledger.Aries/Features/Handshakes/Connection/DefaultConnectionService.cs
+++ b/src/Hyperledger.Aries/Features/Handshakes/Connection/DefaultConnectionService.cs
@@ -120,7 +120,7 @@ namespace Hyperledger.Aries.Features.Handshakes.Connection
         }
 
         /// <inheritdoc />
-        public async Task RevokeInvitationAsync(IAgentContext agentContext, string invitationId)
+        public virtual async Task RevokeInvitationAsync(IAgentContext agentContext, string invitationId)
         {
             var connection = await GetAsync(agentContext, invitationId);
 
@@ -132,7 +132,7 @@ namespace Hyperledger.Aries.Features.Handshakes.Connection
         }
 
         /// <inheritdoc />
-        public async Task<ConnectionRecord> ProcessInvitationAsync(IAgentContext agentContext, ConnectionInvitationMessage invitation)
+        public virtual async Task<ConnectionRecord> ProcessInvitationAsync(IAgentContext agentContext, ConnectionInvitationMessage invitation)
         {
             var my = await Did.CreateAndStoreMyDidAsync(agentContext.Wallet, "{}");
 
@@ -214,7 +214,7 @@ namespace Hyperledger.Aries.Features.Handshakes.Connection
         }
 
         /// <inheritdoc />
-        public async Task<(ConnectionRequestMessage, ConnectionRecord)> CreateRequestAsync(IAgentContext agentContext, ConnectionRecord connection)
+        public virtual async Task<(ConnectionRequestMessage, ConnectionRecord)> CreateRequestAsync(IAgentContext agentContext, ConnectionRecord connection)
         {
             Logger.LogInformation(LoggingEvents.AcceptInvitation, "Key {0}, Endpoint {1}",
                 connection.Endpoint.Verkey, connection.Endpoint.Uri);
@@ -419,7 +419,7 @@ namespace Hyperledger.Aries.Features.Handshakes.Connection
         }
 
         /// <inheritdoc />
-        public async Task<ConnectionAcknowledgeMessage> CreateAcknowledgementMessageAsync(IAgentContext agentContext, string connectionRecordId,
+        public virtual async Task<ConnectionAcknowledgeMessage> CreateAcknowledgementMessageAsync(IAgentContext agentContext, string connectionRecordId,
             string status = AcknowledgementStatusConstants.Ok)
         {
             var record = await GetAsync(agentContext, connectionRecordId);
@@ -436,7 +436,7 @@ namespace Hyperledger.Aries.Features.Handshakes.Connection
         }
 
         /// <inheritdoc />
-        public async Task<ConnectionRecord> ProcessAcknowledgementMessageAsync(IAgentContext agentContext,
+        public virtual async Task<ConnectionRecord> ProcessAcknowledgementMessageAsync(IAgentContext agentContext,
             ConnectionAcknowledgeMessage acknowledgeMessage)
         {
             var connectionRecord = await this.GetByThreadIdAsync(agentContext, acknowledgeMessage.GetThreadId());

--- a/src/Hyperledger.Aries/Features/Handshakes/DidExchange/DefaultDidExchangeService.cs
+++ b/src/Hyperledger.Aries/Features/Handshakes/DidExchange/DefaultDidExchangeService.cs
@@ -37,7 +37,7 @@ namespace Hyperledger.Aries.Features.Handshakes.DidExchange
         }
 
         /// <inheritdoc/>
-        public async Task<ConnectionRecord> ProcessInvitationAsync(IAgentContext agentContext, InvitationMessage invitation)
+        public virtual async Task<ConnectionRecord> ProcessInvitationAsync(IAgentContext agentContext, InvitationMessage invitation)
         {
             if (invitation.HandshakeProtocols.Contains(HandshakeProtocolUri.DidExchange) == false)
                 throw new NotImplementedException("The given handshake protocols are not implemented.");
@@ -84,7 +84,7 @@ namespace Hyperledger.Aries.Features.Handshakes.DidExchange
         }
 
         /// <inheritdoc/>
-        public async Task<(DidExchangeRequestMessage, ConnectionRecord)> CreateRequestAsync(IAgentContext agentContext, string did)
+        public virtual async Task<(DidExchangeRequestMessage, ConnectionRecord)> CreateRequestAsync(IAgentContext agentContext, string did)
         {
             var theirVerkey = await Did.KeyForDidAsync(await agentContext.Pool as Pool, agentContext.Wallet, did);
             var endpointResult = await _ledgerService.LookupServiceEndpointAsync(agentContext, did);
@@ -130,7 +130,7 @@ namespace Hyperledger.Aries.Features.Handshakes.DidExchange
             return (request, connection);
         }
 
-        public async Task<(DidExchangeRequestMessage, ConnectionRecord)> CreateRequestAsync(IAgentContext agentContext, ConnectionRecord record)
+        public virtual async Task<(DidExchangeRequestMessage, ConnectionRecord)> CreateRequestAsync(IAgentContext agentContext, ConnectionRecord record)
         {
             await record.TriggerAsync(ConnectionTrigger.Request);
             
@@ -169,7 +169,7 @@ namespace Hyperledger.Aries.Features.Handshakes.DidExchange
         }
 
         /// <inheritdoc/>
-        public async Task<ConnectionRecord> ProcessRequestAsync(IAgentContext agentContext,
+        public virtual async Task<ConnectionRecord> ProcessRequestAsync(IAgentContext agentContext,
             DidExchangeRequestMessage requestMessage, ConnectionRecord record = null)
         {
             var existingConnectionRecords = await _recordService.SearchAsync<ConnectionRecord>(agentContext.Wallet,
@@ -244,7 +244,7 @@ namespace Hyperledger.Aries.Features.Handshakes.DidExchange
         }
 
         /// <inheritdoc/>
-        public async Task<(DidExchangeResponseMessage, ConnectionRecord)> CreateResponseAsync(IAgentContext agentContext, ConnectionRecord connectionRecord)
+        public virtual async Task<(DidExchangeResponseMessage, ConnectionRecord)> CreateResponseAsync(IAgentContext agentContext, ConnectionRecord connectionRecord)
         {
             await connectionRecord.TriggerAsync(ConnectionTrigger.Response);
 
@@ -287,7 +287,7 @@ namespace Hyperledger.Aries.Features.Handshakes.DidExchange
         }
 
         /// <inheritdoc/>
-        public async Task<ConnectionRecord> ProcessResponseAsync(IAgentContext agentContext, DidExchangeResponseMessage responseMessage, ConnectionRecord connectionRecord)
+        public virtual async Task<ConnectionRecord> ProcessResponseAsync(IAgentContext agentContext, DidExchangeResponseMessage responseMessage, ConnectionRecord connectionRecord)
         {
             await connectionRecord.TriggerAsync(ConnectionTrigger.Response);
             
@@ -337,7 +337,7 @@ namespace Hyperledger.Aries.Features.Handshakes.DidExchange
         }
 
         /// <inheritdoc/>
-        public async Task<(DidExchangeCompleteMessage, ConnectionRecord)> CreateComplete(IAgentContext agentContext, ConnectionRecord connectionRecord)
+        public virtual async Task<(DidExchangeCompleteMessage, ConnectionRecord)> CreateComplete(IAgentContext agentContext, ConnectionRecord connectionRecord)
         {
             await connectionRecord.TriggerAsync(ConnectionTrigger.Complete);
             await _recordService.UpdateAsync(agentContext.Wallet, connectionRecord);
@@ -352,7 +352,7 @@ namespace Hyperledger.Aries.Features.Handshakes.DidExchange
         }
 
         /// <inheritdoc/>
-        public async Task<ConnectionRecord> ProcessComplete(IAgentContext agentContext, DidExchangeCompleteMessage completeMessage,
+        public virtual async Task<ConnectionRecord> ProcessComplete(IAgentContext agentContext, DidExchangeCompleteMessage completeMessage,
             ConnectionRecord connectionRecord)
         {
             await connectionRecord.TriggerAsync(ConnectionTrigger.Complete);
@@ -369,7 +369,7 @@ namespace Hyperledger.Aries.Features.Handshakes.DidExchange
         }
 
         /// <inheritdoc/>
-        public async Task<(DidExchangeProblemReportMessage, ConnectionRecord)> AbandonDidExchange(IAgentContext agentContext, ConnectionRecord connectionRecord)
+        public virtual async Task<(DidExchangeProblemReportMessage, ConnectionRecord)> AbandonDidExchange(IAgentContext agentContext, ConnectionRecord connectionRecord)
         {
             await connectionRecord.TriggerAsync(ConnectionTrigger.Abandon);
             await _recordService.UpdateAsync(agentContext.Wallet, connectionRecord);
@@ -385,7 +385,7 @@ namespace Hyperledger.Aries.Features.Handshakes.DidExchange
         }
 
         /// <inheritdoc/>
-        public async Task<ConnectionRecord> ProcessProblemReportMessage(IAgentContext agentContext, DidExchangeProblemReportMessage problemReportMessage, ConnectionRecord connectionRecord)
+        public virtual async Task<ConnectionRecord> ProcessProblemReportMessage(IAgentContext agentContext, DidExchangeProblemReportMessage problemReportMessage, ConnectionRecord connectionRecord)
         {
             await connectionRecord.TriggerAsync(ConnectionTrigger.Abandon);
             await _recordService.UpdateAsync(agentContext.Wallet, connectionRecord);

--- a/src/Hyperledger.Aries/Features/IssueCredential/DefaultCredentialService.cs
+++ b/src/Hyperledger.Aries/Features/IssueCredential/DefaultCredentialService.cs
@@ -8,12 +8,14 @@ using Hyperledger.Aries.Configuration;
 using Hyperledger.Aries.Contracts;
 using Hyperledger.Aries.Decorators;
 using Hyperledger.Aries.Decorators.Attachments;
+using Hyperledger.Aries.Decorators.PleaseAck;
 using Hyperledger.Aries.Decorators.Service;
 using Hyperledger.Aries.Decorators.Threading;
-using Hyperledger.Aries.Decorators.PleaseAck;
 using Hyperledger.Aries.Extensions;
 using Hyperledger.Aries.Features.Handshakes.Common;
 using Hyperledger.Aries.Features.Handshakes.Connection;
+using Hyperledger.Aries.Features.IssueCredential.Models.Messages;
+using Hyperledger.Aries.Features.RevocationNotification;
 using Hyperledger.Aries.Ledger;
 using Hyperledger.Aries.Models.Events;
 using Hyperledger.Aries.Models.Records;
@@ -26,9 +28,7 @@ using Hyperledger.Indy.BlobStorageApi;
 using Hyperledger.Indy.DidApi;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
-using Hyperledger.Aries.Features.IssueCredential.Models.Messages;
 using Polly;
-using Hyperledger.Aries.Features.RevocationNotification;
 
 namespace Hyperledger.Aries.Features.IssueCredential
 {
@@ -152,7 +152,7 @@ namespace Hyperledger.Aries.Features.IssueCredential
         }
 
         /// <inheritdoc />
-        public async Task RevokeCredentialOfferAsync(IAgentContext agentContext, string offerId)
+        public virtual async Task RevokeCredentialOfferAsync(IAgentContext agentContext, string offerId)
         {
             var credentialRecord = await GetAsync(agentContext, offerId);
 
@@ -240,7 +240,7 @@ namespace Hyperledger.Aries.Features.IssueCredential
         }
 
         /// <inheritdoc />
-        public async Task DeleteCredentialAsync(IAgentContext agentContext, string credentialId)
+        public virtual async Task DeleteCredentialAsync(IAgentContext agentContext, string credentialId)
         {
             var credentialRecord = await GetAsync(agentContext, credentialId);
             try
@@ -256,7 +256,7 @@ namespace Hyperledger.Aries.Features.IssueCredential
         }
 
         /// <inheritdoc />
-        public async Task<CredentialAcknowledgeMessage> CreateAcknowledgementMessageAsync(IAgentContext agentContext, string credentialRecordId,
+        public virtual async Task<CredentialAcknowledgeMessage> CreateAcknowledgementMessageAsync(IAgentContext agentContext, string credentialRecordId,
             string status = AcknowledgementStatusConstants.Ok)
         {
             var record = await GetAsync(agentContext, credentialRecordId);
@@ -273,7 +273,7 @@ namespace Hyperledger.Aries.Features.IssueCredential
         }
 
         /// <inheritdoc />
-        public async Task<CredentialRecord> ProcessAcknowledgementMessageAsync(IAgentContext agentContext,
+        public virtual async Task<CredentialRecord> ProcessAcknowledgementMessageAsync(IAgentContext agentContext,
             CredentialAcknowledgeMessage credentialAcknowledgeMessage)
         {
             var credentialRecord = await this.GetByThreadIdAsync(agentContext, credentialAcknowledgeMessage.GetThreadId());
@@ -334,7 +334,7 @@ namespace Hyperledger.Aries.Features.IssueCredential
         }
 
         /// <inheritdoc />
-        public async Task<CredentialRecord> CreateCredentialAsync(IAgentContext agentContext,
+        public virtual async Task<CredentialRecord> CreateCredentialAsync(IAgentContext agentContext,
             CredentialOfferMessage message)
         {
             var credentialRecordId = "";
@@ -371,7 +371,7 @@ namespace Hyperledger.Aries.Features.IssueCredential
         }
 
         /// <inheritdoc />
-        public async Task<(CredentialRequestMessage, CredentialRecord)> CreateRequestAsync(IAgentContext agentContext,
+        public virtual async Task<(CredentialRequestMessage, CredentialRecord)> CreateRequestAsync(IAgentContext agentContext,
             string credentialId)
         {
             var credential = await GetAsync(agentContext, credentialId);
@@ -483,7 +483,7 @@ namespace Hyperledger.Aries.Features.IssueCredential
         }
 
         /// <inheritdoc />
-        public async Task<(CredentialOfferMessage, CredentialRecord)> CreateOfferAsync(
+        public virtual async Task<(CredentialOfferMessage, CredentialRecord)> CreateOfferAsync(
             IAgentContext agentContext, OfferConfiguration config, string connectionId)
         {
             Logger.LogInformation(LoggingEvents.CreateCredentialOffer, "DefinitionId {0}, IssuerDid {1}",
@@ -567,7 +567,7 @@ namespace Hyperledger.Aries.Features.IssueCredential
         }
 
         /// <inheritdoc />
-        public async Task<(CredentialOfferMessage, CredentialRecord)> CreateOfferAsync(
+        public virtual async Task<(CredentialOfferMessage, CredentialRecord)> CreateOfferAsync(
             IAgentContext agentContext, OfferConfiguration config)
         {
             if (config is null)
@@ -621,14 +621,14 @@ namespace Hyperledger.Aries.Features.IssueCredential
         }
 
         /// <inheritdoc />
-        public Task<(CredentialIssueMessage, CredentialRecord)> CreateCredentialAsync(IAgentContext agentContext, string
+        public virtual Task<(CredentialIssueMessage, CredentialRecord)> CreateCredentialAsync(IAgentContext agentContext, string
             credentialId)
         {
             return CreateCredentialAsync(agentContext, credentialId, values: null);
         }
 
         /// <inheritdoc />
-        public async Task<(CredentialIssueMessage, CredentialRecord)> CreateCredentialAsync(IAgentContext agentContext,
+        public virtual async Task<(CredentialIssueMessage, CredentialRecord)> CreateCredentialAsync(IAgentContext agentContext,
             string credentialId, IEnumerable<CredentialPreviewAttribute> values)
         {
             var credentialRecord = await GetAsync(agentContext, credentialId);

--- a/src/Hyperledger.Aries/Features/IssueCredential/DefaultSchemaService.cs
+++ b/src/Hyperledger.Aries/Features/IssueCredential/DefaultSchemaService.cs
@@ -2,20 +2,19 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
-using Hyperledger.Aries.Contracts;
+using Flurl;
 using Hyperledger.Aries.Agents;
-using Hyperledger.Aries.Extensions;
-using Hyperledger.Aries.Models.Records;
-using Hyperledger.Indy.AnonCredsApi;
-using Hyperledger.Indy.PoolApi;
-using Hyperledger.Indy.WalletApi;
-using Newtonsoft.Json.Linq;
 using Hyperledger.Aries.Configuration;
+using Hyperledger.Aries.Contracts;
+using Hyperledger.Aries.Extensions;
 using Hyperledger.Aries.Ledger;
+using Hyperledger.Aries.Models.Records;
 using Hyperledger.Aries.Payments;
 using Hyperledger.Aries.Storage;
+using Hyperledger.Indy.AnonCredsApi;
+using Hyperledger.Indy.WalletApi;
 using Microsoft.Extensions.Options;
-using Flurl;
+using Newtonsoft.Json.Linq;
 
 namespace Hyperledger.Aries.Features.IssueCredential
 {
@@ -106,7 +105,7 @@ namespace Hyperledger.Aries.Features.IssueCredential
         }
 
         /// <inheritdoc />
-        public async Task<string> LookupSchemaFromCredentialDefinitionAsync(IAgentContext agentContext,
+        public virtual async Task<string> LookupSchemaFromCredentialDefinitionAsync(IAgentContext agentContext,
             string credentialDefinitionId)
         {
             var credDef = await LookupCredentialDefinitionAsync(agentContext, credentialDefinitionId);
@@ -183,7 +182,7 @@ namespace Hyperledger.Aries.Features.IssueCredential
         }
 
         /// <inheritdoc />
-        public async Task<string> CreateCredentialDefinitionAsync(IAgentContext context, CredentialDefinitionConfiguration configuration)
+        public virtual async Task<string> CreateCredentialDefinitionAsync(IAgentContext context, CredentialDefinitionConfiguration configuration)
         {
             if (configuration == null) throw new AriesFrameworkException(ErrorCode.InvalidParameterFormat, "Configuration must be specified.");
             if (configuration.SchemaId == null) throw new AriesFrameworkException(ErrorCode.InvalidParameterFormat, "SchemaId must be specified.");
@@ -237,7 +236,7 @@ namespace Hyperledger.Aries.Features.IssueCredential
         }
 
         /// <inheritdoc />
-        public async Task<(IssuerCreateAndStoreRevocRegResult, RevocationRegistryRecord)> CreateRevocationRegistryAsync(
+        public virtual async Task<(IssuerCreateAndStoreRevocRegResult, RevocationRegistryRecord)> CreateRevocationRegistryAsync(
                     IAgentContext context,
                     string tag,
                     DefinitionRecord definitionRecord)

--- a/src/Hyperledger.Aries/Features/PresentProof/DefaultProofService.cs
+++ b/src/Hyperledger.Aries/Features/PresentProof/DefaultProofService.cs
@@ -176,13 +176,13 @@ namespace Hyperledger.Aries.Features.PresentProof
         }
 
         /// <inheritdoc />
-        public async Task<bool> IsRevokedAsync(IAgentContext context, string credentialRecordId)
+        public virtual async Task<bool> IsRevokedAsync(IAgentContext context, string credentialRecordId)
         {
             return await IsRevokedAsync(context, await RecordService.GetAsync<CredentialRecord>(context.Wallet, credentialRecordId));
         }
 
         /// <inheritdoc />
-        public async Task<bool> IsRevokedAsync(IAgentContext context, CredentialRecord record)
+        public virtual async Task<bool> IsRevokedAsync(IAgentContext context, CredentialRecord record)
         {
             if (record.RevocationRegistryId == null) return false;
             if (record.State == CredentialState.Offered || record.State == CredentialState.Requested) return false;
@@ -314,7 +314,8 @@ namespace Hyperledger.Aries.Features.PresentProof
         }
 
         /// <inheritdoc />
-        public async Task<PresentationAcknowledgeMessage> CreateAcknowledgeMessageAsync(IAgentContext agentContext, string proofRecordId, string status = AcknowledgementStatusConstants.Ok)
+        public virtual async Task<PresentationAcknowledgeMessage> CreateAcknowledgeMessageAsync(IAgentContext agentContext, 
+            string proofRecordId, string status = AcknowledgementStatusConstants.Ok)
         {
             var record = await GetAsync(agentContext, proofRecordId);
             
@@ -426,8 +427,8 @@ namespace Hyperledger.Aries.Features.PresentProof
         }
 
         /// <inheritdoc />
-        public async Task<(RequestPresentationMessage, ProofRecord)> CreateRequestFromProposalAsync(IAgentContext agentContext, ProofRequestParameters requestParams,
-            string proofRecordId, string connectionId)
+        public virtual async Task<(RequestPresentationMessage, ProofRecord)> CreateRequestFromProposalAsync(
+            IAgentContext agentContext, ProofRequestParameters requestParams, string proofRecordId, string connectionId)
         {
             Logger.LogInformation(LoggingEvents.CreateProofRequest, "ConnectionId {0}", connectionId);
 
@@ -552,7 +553,7 @@ namespace Hyperledger.Aries.Features.PresentProof
         }
 
         /// <inheritdoc />
-        public Task<(RequestPresentationMessage, ProofRecord)> CreateRequestAsync(
+        public virtual Task<(RequestPresentationMessage, ProofRecord)> CreateRequestAsync(
             IAgentContext agentContext,
             ProofRequest proofRequest,
             string connectionId) =>

--- a/src/Hyperledger.Aries/Ledger/DefaultLedgerService.cs
+++ b/src/Hyperledger.Aries/Ledger/DefaultLedgerService.cs
@@ -113,7 +113,7 @@ namespace Hyperledger.Aries.Ledger
         }
 
         /// <inheritdoc />
-        public async Task<ServiceEndpointResult> LookupServiceEndpointAsync(IAgentContext context, string did)
+        public virtual async Task<ServiceEndpointResult> LookupServiceEndpointAsync(IAgentContext context, string did)
         {
             var res = await LookupAttributeAsync(context, did, "endpoint");
             var jobj = JObject.Parse(res);
@@ -122,7 +122,7 @@ namespace Hyperledger.Aries.Ledger
         }
 
         /// <inheritdoc />
-        public async Task RegisterServiceEndpointAsync(IAgentContext context, string did, string serviceEndpoint, TransactionCost paymentInfo = null)
+        public virtual async Task RegisterServiceEndpointAsync(IAgentContext context, string did, string serviceEndpoint, TransactionCost paymentInfo = null)
         {
             var value = new {endpoint = serviceEndpoint};
             await RegisterAttributeAsync(context, did, did, "endpoint", value);
@@ -198,7 +198,7 @@ namespace Hyperledger.Aries.Ledger
         }
 
         /// <inheritdoc />
-        public async Task<string> LookupNymAsync(IAgentContext agentContext, string did)
+        public virtual async Task<string> LookupNymAsync(IAgentContext agentContext, string did)
         {
             var req = await IndyLedger.BuildGetNymRequestAsync(null, did);
             var res = await IndyLedger.SubmitRequestAsync(await agentContext.Pool as Pool, req);
@@ -209,7 +209,7 @@ namespace Hyperledger.Aries.Ledger
         }
 
         /// <inheritdoc />
-        public async Task<IList<AuthorizationRule>> LookupAuthorizationRulesAsync(IAgentContext agentContext)
+        public virtual async Task<IList<AuthorizationRule>> LookupAuthorizationRulesAsync(IAgentContext agentContext)
         {
             var req = await IndyLedger.BuildGetAuthRuleRequestAsync(null, null, null, null, null, null);
             var res = await IndyLedger.SubmitRequestAsync(await agentContext.Pool as Pool, req);

--- a/src/Hyperledger.Aries/Ledger/DefaultLedgerSigningService.cs
+++ b/src/Hyperledger.Aries/Ledger/DefaultLedgerSigningService.cs
@@ -18,7 +18,7 @@ namespace Hyperledger.Aries.Ledger
             this.provisioningService = provisioningService;
         }
         /// <inheritdoc />
-        public async Task<string> SignRequestAsync(IAgentContext context, string submitterDid, string requestJson)
+        public virtual async Task<string> SignRequestAsync(IAgentContext context, string submitterDid, string requestJson)
         {
             try
             {
@@ -38,7 +38,7 @@ namespace Hyperledger.Aries.Ledger
         }
 
         /// <inheritdoc />
-        public Task<string> SignRequestAsync(Wallet wallet, string submitterDid, string requestJson)
+        public virtual Task<string> SignRequestAsync(Wallet wallet, string submitterDid, string requestJson)
         {
             return IndyLedger.SignRequestAsync(wallet, submitterDid, requestJson);
         }

--- a/src/Hyperledger.Aries/Ledger/DefaultPoolService.cs
+++ b/src/Hyperledger.Aries/Ledger/DefaultPoolService.cs
@@ -60,13 +60,13 @@ namespace Hyperledger.Aries.Ledger
         }
 
         /// <inheritdoc />
-        public Task<string> SubmitRequestAsync(PoolAwaitable poolHandle, object requestHandle)
+        public virtual Task<string> SubmitRequestAsync(PoolAwaitable poolHandle, object requestHandle)
         {
             throw new NotImplementedException($"{nameof(SubmitRequestAsync)} is not implemented within DefaultLedgerService; use DefaultLedgerServiceV2 instead");
         }
 
         /// <inheritdoc />
-        public async Task<IndyTaa> GetTaaAsync(string poolName)
+        public virtual async Task<IndyTaa> GetTaaAsync(string poolName)
         {
             IndyTaa ParseTaa(string response)
             {
@@ -107,7 +107,7 @@ namespace Hyperledger.Aries.Ledger
         }
 
         /// <inheritdoc />
-        public async Task<IndyAml> GetAmlAsync(string poolName, DateTimeOffset timestamp = default, string version = null)
+        public virtual async Task<IndyAml> GetAmlAsync(string poolName, DateTimeOffset timestamp = default, string version = null)
         {
             IndyAml ParseAml(string response)
             {

--- a/src/Hyperledger.Aries/Payments/DefaultPaymentService.cs
+++ b/src/Hyperledger.Aries/Payments/DefaultPaymentService.cs
@@ -8,61 +8,61 @@ namespace Hyperledger.Aries.Payments
     public class DefaultPaymentService : IPaymentService
     {
         /// <inheritdoc />
-        public void AttachPaymentReceipt(IAgentContext context, AgentMessage agentMessage, PaymentRecord paymentRecord)
+        public virtual void AttachPaymentReceipt(IAgentContext context, AgentMessage agentMessage, PaymentRecord paymentRecord)
         {
             throw new NotImplementedException();
         }
 
         /// <inheritdoc />
-        public Task<PaymentRecord> AttachPaymentRequestAsync(IAgentContext context, AgentMessage agentMessage, PaymentDetails details, PaymentAddressRecord addressRecord = null)
+        public virtual Task<PaymentRecord> AttachPaymentRequestAsync(IAgentContext context, AgentMessage agentMessage, PaymentDetails details, PaymentAddressRecord addressRecord = null)
         {
             throw new NotImplementedException();
         }
 
         /// <inheritdoc />
-        public Task<PaymentAddressRecord> CreatePaymentAddressAsync(IAgentContext agentContext, AddressOptions configuration = null)
+        public virtual Task<PaymentAddressRecord> CreatePaymentAddressAsync(IAgentContext agentContext, AddressOptions configuration = null)
         {
             throw new NotSupportedException();
         }
 
         /// <inheritdoc />
-        public Task<TransactionCost> GetTransactionCostAsync(IAgentContext context, string transactionType, PaymentAddressRecord addressRecord = null)
+        public virtual Task<TransactionCost> GetTransactionCostAsync(IAgentContext context, string transactionType, PaymentAddressRecord addressRecord = null)
         {
             return Task.FromResult<TransactionCost>(null);
         }
 
         /// <inheritdoc />
-        public Task RefreshBalanceAsync(IAgentContext agentContext, PaymentAddressRecord paymentAddress = null)
+        public virtual Task RefreshBalanceAsync(IAgentContext agentContext, PaymentAddressRecord paymentAddress = null)
         {
             throw new NotSupportedException();
         }
 
         /// <inheritdoc />
-        public Task<PaymentAddressRecord> GetDefaultPaymentAddressAsync(IAgentContext agentContext)
+        public virtual Task<PaymentAddressRecord> GetDefaultPaymentAddressAsync(IAgentContext agentContext)
         {
             throw new NotImplementedException();
         }
 
         /// <inheritdoc />
-        public Task<ulong> GetTransactionFeeAsync(IAgentContext agentContext, string transactionType)
+        public virtual Task<ulong> GetTransactionFeeAsync(IAgentContext agentContext, string transactionType)
         {
             return Task.FromResult(0UL);
         }
 
         /// <inheritdoc />
-        public Task MakePaymentAsync(IAgentContext agentContext, PaymentRecord paymentRecord, PaymentAddressRecord addressRecord = null)
+        public virtual Task MakePaymentAsync(IAgentContext agentContext, PaymentRecord paymentRecord, PaymentAddressRecord addressRecord = null)
         {
             throw new NotSupportedException();
         }
 
         /// <inheritdoc />
-        public Task SetDefaultPaymentAddressAsync(IAgentContext agentContext, PaymentAddressRecord addressRecord)
+        public virtual Task SetDefaultPaymentAddressAsync(IAgentContext agentContext, PaymentAddressRecord addressRecord)
         {
             throw new NotSupportedException();
         }
 
         /// <inheritdoc />
-        public Task<bool> VerifyPaymentAsync(IAgentContext context, PaymentRecord paymentRecord)
+        public virtual Task<bool> VerifyPaymentAsync(IAgentContext context, PaymentRecord paymentRecord)
         {
             throw new NotImplementedException();
         }

--- a/src/Hyperledger.Aries/Signatures/DefaultSigningService.cs
+++ b/src/Hyperledger.Aries/Signatures/DefaultSigningService.cs
@@ -8,12 +8,12 @@ namespace Hyperledger.Aries.Signatures
 {
     public class DefaultSigningService : ISigningService
     {
-        public Task<byte[]> SignMessageAsync(IAgentContext context, string signingDid, string message)
+        public virtual Task<byte[]> SignMessageAsync(IAgentContext context, string signingDid, string message)
         {
             return SignMessageAsync(context, signingDid, Encoding.UTF8.GetBytes(message));
         }
         
-        public async Task<byte[]> SignMessageAsync(IAgentContext context, string signingDid, byte[] message)
+        public virtual async Task<byte[]> SignMessageAsync(IAgentContext context, string signingDid, byte[] message)
         {
             var key = await Did.KeyForLocalDidAsync(context.Wallet, signingDid);
             return await Crypto.SignAsync(context.Wallet, key, message);


### PR DESCRIPTION
Signed-off-by: Sebastian Bickerle <sebastian.bickerle@main-incubator.com>

#### Short description of what this resolves:

This PR adds the virtual modifier to all public methods of default services where it was missing. It enables custom services to override the default behaviour or add a custom behaviour. All public methods of default services should have the virtual modifier by default.

#### Changes proposed in this pull request:

- Adds virtual modifier to all public methods of default services
