### PR TITLE
Allow arbitrary mime types for credential attributes

### DIFF
--- a/src/Hyperledger.Aries/Features/IssueCredential/DefaultCredentialService.cs
+++ b/src/Hyperledger.Aries/Features/IssueCredential/DefaultCredentialService.cs
@@ -501,11 +501,6 @@ namespace Hyperledger.Aries.Features.IssueCredential
                 }
             }
 
-            if (config.CredentialAttributeValues != null && config.CredentialAttributeValues.Any())
-            {
-                CredentialUtils.ValidateCredentialPreviewAttributes(config.CredentialAttributeValues);
-            }
-
             var offerJson = await AnonCreds.IssuerCreateCredentialOfferAsync(
                 agentContext.Wallet, config.CredentialDefinitionId);
 

--- a/src/Hyperledger.Aries/Features/IssueCredential/Models/CredentialMimeTypes.cs
+++ b/src/Hyperledger.Aries/Features/IssueCredential/Models/CredentialMimeTypes.cs
@@ -16,7 +16,12 @@
         public const string ApplicationJsonMimeType = "application/json";
         
         /// <summary>
-        /// MIME type for images in PNG format. The content should be a PNG file which is encoded in Base64.
+        /// MIME type for PDFs. The content should be a PDF file encoded in Base64.
+        /// </summary>
+        public const string ApplicationPdfMimeType = "application/pdf";
+        
+        /// <summary>
+        /// MIME type for images in PNG format. The content should be a PNG file encoded in Base64.
         /// </summary>
         public const string ImagePngMimeType = "image/png";
     }

--- a/src/Hyperledger.Aries/Utils/CredentialUtils.cs
+++ b/src/Hyperledger.Aries/Utils/CredentialUtils.cs
@@ -22,24 +22,8 @@ namespace Hyperledger.Aries.Utils
         /// <param name="credentialAttributes">The credential attributes.</param>
         public static string FormatCredentialValues(IEnumerable<CredentialPreviewAttribute> credentialAttributes)
         {
-            if (credentialAttributes == null)
-                return null;
-
-            var result = new Dictionary<string, Dictionary<string, string>>();
-            foreach (var item in credentialAttributes)
-            {
-                switch (item.MimeType)
-                {
-                    case CredentialMimeTypes.TextMimeType:
-                    case CredentialMimeTypes.ApplicationJsonMimeType:
-                    case CredentialMimeTypes.ImagePngMimeType:
-                        result.Add(item.Name, FormatStringCredentialAttribute(item));
-                        break;
-                    default:
-                        throw new AriesFrameworkException(ErrorCode.InvalidParameterFormat, $"{item.Name} mime type of {item.MimeType} not supported");
-                }
-            }
-            return result.ToJson();
+            var result = credentialAttributes?.ToDictionary(item => item.Name, FormatStringCredentialAttribute);
+            return result?.ToJson();
         }
 
         static SHA256 sha256 = SHA256.Create();
@@ -139,15 +123,7 @@ namespace Hyperledger.Aries.Utils
         /// <returns></returns>
         public static object CastAttribute(object attributeValue, string mimeType)
         {
-            switch (mimeType)
-            {
-                case CredentialMimeTypes.TextMimeType:
-                case CredentialMimeTypes.ApplicationJsonMimeType:
-                case CredentialMimeTypes.ImagePngMimeType:
-                    return (string)attributeValue;
-                default:
-                    throw new AriesFrameworkException(ErrorCode.InvalidParameterFormat, $"Mime type of {mimeType} not supported");
-            }
+            return (string)attributeValue;
         }
 
         /// <summary>
@@ -158,17 +134,7 @@ namespace Hyperledger.Aries.Utils
         /// <returns></returns>
         public static object CastAttribute(JToken attributeValue, string mimeType)
         {
-            switch (mimeType)
-            {
-                case null:
-                    return attributeValue.Value<string>();
-                case CredentialMimeTypes.TextMimeType:
-                case CredentialMimeTypes.ApplicationJsonMimeType:
-                case CredentialMimeTypes.ImagePngMimeType:
-                    return attributeValue.Value<string>();
-                default:
-                    throw new AriesFrameworkException(ErrorCode.InvalidParameterFormat, $"Mime type of {mimeType} not supported");
-            }
+            return attributeValue.Value<string>();
         }
 
         /// <summary>


### PR DESCRIPTION
#### Short description of what this resolves:

Currently, in order to add support for new mime types in credential attributes one has to adjust the framework and add the wanted mime type. This PR proposes the option to allow any arbitrary mime types by removing the validation check of mime types.

#### Changes proposed in this pull request:

- Removes strict validation of credential attribute mime types in order to enable arbitrary mime types
